### PR TITLE
Add media tier ranking for TV series and movies

### DIFF
--- a/drizzle/0011_lovely_alex_wilder.sql
+++ b/drizzle/0011_lovely_alex_wilder.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `media` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`media_type` text NOT NULL,
+	`tier` text NOT NULL,
+	`genre` text,
+	`release_year` integer,
+	`tmdb_id` text,
+	`poster_url` text,
+	`comment` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1075 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "75157ddb-7c81-4427-a66a-799ed3a5d9d3",
+  "prevId": "f69c329f-a4d1-464b-9885-b225bbeeef86",
+  "tables": {
+    "always_do_logs": {
+      "name": "always_do_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "always_do_logs_session_id_exercise_sessions_id_fk": {
+          "name": "always_do_logs_session_id_exercise_sessions_id_fk",
+          "tableFrom": "always_do_logs",
+          "tableTo": "exercise_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exercise_logs": {
+      "name": "exercise_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "set_number": {
+          "name": "set_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reps": {
+          "name": "reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_logs_session_id_exercise_sessions_id_fk": {
+          "name": "exercise_logs_session_id_exercise_sessions_id_fk",
+          "tableFrom": "exercise_logs",
+          "tableTo": "exercise_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exercise_sessions": {
+      "name": "exercise_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exercise_sessions_date_unique": {
+          "name": "exercise_sessions_date_unique",
+          "columns": [
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fitbit_daily_data": {
+      "name": "fitbit_daily_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "zone_out_of_range": {
+          "name": "zone_out_of_range",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zone_fat_burn": {
+          "name": "zone_fat_burn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zone_cardio": {
+          "name": "zone_cardio",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zone_peak": {
+          "name": "zone_peak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resting_heart_rate": {
+          "name": "resting_heart_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sleep_duration": {
+          "name": "sleep_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sleep_efficiency": {
+          "name": "sleep_efficiency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sleep_deep": {
+          "name": "sleep_deep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sleep_light": {
+          "name": "sleep_light",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sleep_rem": {
+          "name": "sleep_rem",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sleep_awake": {
+          "name": "sleep_awake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calories_burned": {
+          "name": "calories_burned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fitbit_daily_data_date_unique": {
+          "name": "fitbit_daily_data_date_unique",
+          "columns": [
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fitness_entries": {
+      "name": "fitness_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_distance": {
+          "name": "walk_distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_incline": {
+          "name": "walk_incline",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "breakfast": {
+          "name": "breakfast",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "brush": {
+          "name": "brush",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "floss": {
+          "name": "floss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "shower": {
+          "name": "shower",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "shake": {
+          "name": "shake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fitness_entries_date_unique": {
+          "name": "fitness_entries_date_unique",
+          "columns": [
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fitness_goals": {
+      "name": "fitness_goals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "target_weight": {
+          "name": "target_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meal_prep_settings": {
+      "name": "meal_prep_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "breakfast": {
+          "name": "breakfast",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "salmon": {
+          "name": "salmon",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "bean_soup": {
+          "name": "bean_soup",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "med_bowl": {
+          "name": "med_bowl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_url": {
+          "name": "poster_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_tokens": {
+      "name": "oauth_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_tokens_provider_idx": {
+          "name": "oauth_tokens_provider_idx",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shopping_items": {
+      "name": "shopping_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'to_buy'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ordered_at": {
+          "name": "ordered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_label_assignments": {
+      "name": "task_label_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_label_assignments_task_id_tasks_id_fk": {
+          "name": "task_label_assignments_task_id_tasks_id_fk",
+          "tableFrom": "task_label_assignments",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_label_assignments_label_id_task_labels_id_fk": {
+          "name": "task_label_assignments_label_id_task_labels_id_fk",
+          "tableFrom": "task_label_assignments",
+          "tableTo": "task_labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_labels": {
+      "name": "task_labels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "task_labels_name_unique": {
+          "name": "task_labels_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'todo'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "video_games": {
+      "name": "video_games",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steam_app_id": {
+          "name": "steam_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1767641604649,
       "tag": "0010_chubby_ravenous",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1767656303806,
+      "tag": "0011_lovely_alex_wilder",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/games/types.ts
+++ b/src/lib/components/games/types.ts
@@ -1,44 +1,28 @@
-export type Game = {
-  id: number;
-  name: string;
-  genre: string | null;
-  tier: string;
-  releaseYear: number | null;
-  comment: string | null;
-  steamAppId: string | null;
-  coverUrl: string | null;
-  sortOrder: number;
-  createdAt: string;
-  updatedAt: string;
-  // Optional fields for unranked games (from Steam API)
-  playtimeHours?: number;
-  lastPlayed?: number | null; // Unix timestamp
-};
+import { type Tier, type TierConfig, TIER_CONFIGS, TIER_ORDER } from '../shared/tiers';
 
-export type GameTier = 'S' | 'A+' | 'A' | 'A-' | 'B+' | 'B' | 'B-' | 'C+' | 'C';
+// Re-export shared tier types for backwards compatibility
+export type GameTier = Tier;
+export type { TierConfig };
+export { TIER_CONFIGS, TIER_ORDER };
+
+export type Game = {
+	id: number;
+	name: string;
+	genre: string | null;
+	tier: string;
+	releaseYear: number | null;
+	comment: string | null;
+	steamAppId: string | null;
+	coverUrl: string | null;
+	sortOrder: number;
+	createdAt: string;
+	updatedAt: string;
+	// Optional fields for unranked games (from Steam API)
+	playtimeHours?: number;
+	lastPlayed?: number | null; // Unix timestamp
+};
 
 // Unranked games from Steam have negative IDs (based on -appid)
 export function isUnrankedGame(game: Game): boolean {
-  return game.id < 0;
+	return game.id < 0;
 }
-
-export type TierConfig = {
-  id: GameTier;
-  title: string;
-  color: string;
-  bgColor: string;
-};
-
-export const TIER_CONFIGS: Record<GameTier, TierConfig> = {
-  S: { id: 'S', title: 'S', color: '#fbbf24', bgColor: 'rgba(251, 191, 36, 0.15)' },
-  'A+': { id: 'A+', title: 'A+', color: '#a3e635', bgColor: 'rgba(163, 230, 53, 0.15)' },
-  A: { id: 'A', title: 'A', color: '#22c55e', bgColor: 'rgba(34, 197, 94, 0.15)' },
-  'A-': { id: 'A-', title: 'A-', color: '#34d399', bgColor: 'rgba(52, 211, 153, 0.15)' },
-  'B+': { id: 'B+', title: 'B+', color: '#38bdf8', bgColor: 'rgba(56, 189, 248, 0.15)' },
-  B: { id: 'B', title: 'B', color: '#60a5fa', bgColor: 'rgba(96, 165, 250, 0.15)' },
-  'B-': { id: 'B-', title: 'B-', color: '#818cf8', bgColor: 'rgba(129, 140, 248, 0.15)' },
-  'C+': { id: 'C+', title: 'C+', color: '#a78bfa', bgColor: 'rgba(167, 139, 250, 0.15)' },
-  C: { id: 'C', title: 'C', color: '#c084fc', bgColor: 'rgba(192, 132, 252, 0.15)' },
-};
-
-export const TIER_ORDER: GameTier[] = ['S', 'A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C'];

--- a/src/lib/components/media/AddMediaModal.svelte
+++ b/src/lib/components/media/AddMediaModal.svelte
@@ -1,0 +1,401 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { MediaTier, MediaType } from './types';
+	import { TIER_ORDER, TIER_CONFIGS } from './types';
+
+	type SearchResult = {
+		id: number;
+		name: string;
+		releaseYear: number | null;
+		posterUrl: string | null;
+		overview: string;
+		genres: string[];
+	};
+
+	type Props = {
+		isOpen: boolean;
+		mediaType: MediaType;
+		onClose: () => void;
+		onSuccess?: () => void;
+	};
+
+	let { isOpen, mediaType, onClose, onSuccess }: Props = $props();
+
+	// Search state
+	let searchQuery = $state('');
+	let searchResults = $state<SearchResult[]>([]);
+	let isSearching = $state(false);
+	let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	// Form state
+	let selectedResult = $state<SearchResult | null>(null);
+	let name = $state('');
+	let genre = $state('');
+	let tier = $state<MediaTier>('B');
+	let releaseYear = $state('');
+	let comment = $state('');
+	let tmdbId = $state('');
+	let posterUrl = $state('');
+
+	// Debounced search
+	function handleSearchInput() {
+		if (searchTimeout) clearTimeout(searchTimeout);
+
+		if (searchQuery.length < 2) {
+			searchResults = [];
+			return;
+		}
+
+		searchTimeout = setTimeout(async () => {
+			isSearching = true;
+			try {
+				const endpoint = mediaType === 'tv' ? '/api/tmdb/search/tv' : '/api/tmdb/search/movie';
+				const response = await fetch(`${endpoint}?query=${encodeURIComponent(searchQuery)}`);
+				if (response.ok) {
+					searchResults = await response.json();
+				}
+			} catch (error) {
+				console.error('Search error:', error);
+			} finally {
+				isSearching = false;
+			}
+		}, 300);
+	}
+
+	function selectResult(result: SearchResult) {
+		selectedResult = result;
+		name = result.name;
+		releaseYear = result.releaseYear?.toString() ?? '';
+		genre = result.genres[0] ?? '';
+		tmdbId = result.id.toString();
+		posterUrl = result.posterUrl ?? '';
+		searchQuery = '';
+		searchResults = [];
+	}
+
+	function clearSelection() {
+		selectedResult = null;
+		name = '';
+		genre = '';
+		releaseYear = '';
+		tmdbId = '';
+		posterUrl = '';
+	}
+
+	function resetForm() {
+		searchQuery = '';
+		searchResults = [];
+		selectedResult = null;
+		name = '';
+		genre = '';
+		tier = 'B';
+		releaseYear = '';
+		comment = '';
+		tmdbId = '';
+		posterUrl = '';
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			onClose();
+		}
+	}
+
+	// Reset form when modal opens/closes
+	$effect(() => {
+		if (!isOpen) {
+			resetForm();
+		}
+	});
+
+	let mediaTypeLabel = $derived(mediaType === 'tv' ? 'Series' : 'Movie');
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if isOpen}
+	<div
+		class="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in"
+		onclick={(e) => {
+			if (e.target === e.currentTarget) onClose();
+		}}
+		onkeydown={(e) => {
+			if (e.key === 'Escape') onClose();
+		}}
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="modal-title"
+		tabindex="-1"
+	>
+		<div
+			class="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-xl p-6 w-[500px] max-h-[90vh] overflow-y-auto shadow-2xl animate-scale-in"
+		>
+			<h3 id="modal-title" class="text-lg font-semibold text-[var(--color-text)] mb-4">
+				Add {mediaTypeLabel}
+			</h3>
+
+			<form
+				method="POST"
+				action="?/createMedia"
+				use:enhance={() => {
+					return async ({ update, result }) => {
+						await update({ reset: false });
+						if (result.type === 'success') {
+							resetForm();
+							if (onSuccess) {
+								onSuccess();
+							} else {
+								onClose();
+							}
+						}
+					};
+				}}
+			>
+				<input type="hidden" name="mediaType" value={mediaType} />
+				<input type="hidden" name="tmdbId" value={tmdbId} />
+				<input type="hidden" name="posterUrl" value={posterUrl} />
+
+				<!-- TMDB Search -->
+				<div class="mb-4 relative">
+					<label for="search" class="block text-sm font-medium text-[var(--color-text-muted)] mb-1">
+						Search TMDB
+					</label>
+					<div class="relative">
+						<input
+							type="text"
+							id="search"
+							bind:value={searchQuery}
+							oninput={handleSearchInput}
+							class="w-full bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+							placeholder="Search for {mediaTypeLabel.toLowerCase()}..."
+							autocomplete="off"
+						/>
+						{#if isSearching}
+							<div class="absolute right-3 top-1/2 -translate-y-1/2">
+								<div
+									class="w-4 h-4 border-2 border-[var(--color-accent)] border-t-transparent rounded-full animate-spin"
+								></div>
+							</div>
+						{/if}
+
+						<!-- Search Results Dropdown -->
+						{#if searchResults.length > 0}
+							<div
+								class="absolute left-0 right-0 z-20 mt-1 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg shadow-xl max-h-64 overflow-y-auto"
+							>
+							{#each searchResults as result}
+								<button
+									type="button"
+									onclick={() => selectResult(result)}
+									class="w-full flex items-start gap-3 p-2 hover:bg-[var(--color-bg)] transition-colors text-left"
+								>
+									{#if result.posterUrl}
+										<img
+											src={result.posterUrl}
+											alt=""
+											class="w-10 h-15 object-cover rounded shrink-0"
+										/>
+									{:else}
+										<div
+											class="w-10 h-15 bg-[var(--color-bg)] rounded shrink-0 flex items-center justify-center"
+										>
+											<span class="text-[var(--color-text-muted)] text-xs">?</span>
+										</div>
+									{/if}
+									<div class="flex-1 min-w-0">
+										<p class="text-sm font-medium text-[var(--color-text)] truncate">
+											{result.name}
+										</p>
+										<p class="text-xs text-[var(--color-text-muted)]">
+											{result.releaseYear ?? 'Unknown year'}
+											{#if result.genres.length > 0}
+												&middot; {result.genres[0]}
+											{/if}
+										</p>
+									</div>
+								</button>
+							{/each}
+						</div>
+					{/if}
+					</div>
+				</div>
+
+				<!-- Selected Result Preview -->
+				{#if selectedResult}
+					<div
+						class="mb-4 p-3 bg-[var(--color-bg)] border border-[var(--color-accent)]/30 rounded-lg flex items-start gap-3"
+					>
+						{#if selectedResult.posterUrl}
+							<img
+								src={selectedResult.posterUrl}
+								alt=""
+								class="w-16 h-24 object-cover rounded shrink-0"
+							/>
+						{/if}
+						<div class="flex-1 min-w-0">
+							<p class="font-medium text-[var(--color-text)]">{selectedResult.name}</p>
+							<p class="text-xs text-[var(--color-text-muted)] mt-0.5">
+								{selectedResult.releaseYear ?? 'Unknown'}
+								{#if selectedResult.genres.length > 0}
+									&middot; {selectedResult.genres.join(', ')}
+								{/if}
+							</p>
+							{#if selectedResult.overview}
+								<p class="text-xs text-[var(--color-text-muted)] mt-1 line-clamp-2">
+									{selectedResult.overview}
+								</p>
+							{/if}
+						</div>
+						<button
+							type="button"
+							onclick={clearSelection}
+							class="text-[var(--color-text-muted)] hover:text-[var(--color-text)] p-1"
+							title="Clear selection"
+						>
+							&times;
+						</button>
+					</div>
+				{/if}
+
+				<!-- Name (required) -->
+				<div class="mb-4">
+					<label for="name" class="block text-sm font-medium text-[var(--color-text-muted)] mb-1">
+						Name <span class="text-red-400">*</span>
+					</label>
+					<input
+						type="text"
+						id="name"
+						name="name"
+						bind:value={name}
+						required
+						class="w-full bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+						placeholder="{mediaTypeLabel} name"
+					/>
+				</div>
+
+				<!-- Tier -->
+				<div class="mb-4">
+					<label for="tier" class="block text-sm font-medium text-[var(--color-text-muted)] mb-1">
+						Tier
+					</label>
+					<select
+						id="tier"
+						name="tier"
+						bind:value={tier}
+						class="w-full bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+					>
+						{#each TIER_ORDER as t}
+							<option value={t} style="color: {TIER_CONFIGS[t].color}">
+								{t} tier
+							</option>
+						{/each}
+					</select>
+				</div>
+
+				<!-- Genre -->
+				<div class="mb-4">
+					<label for="genre" class="block text-sm font-medium text-[var(--color-text-muted)] mb-1">
+						Genre
+					</label>
+					<input
+						type="text"
+						id="genre"
+						name="genre"
+						bind:value={genre}
+						class="w-full bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+						placeholder="e.g., Drama"
+					/>
+				</div>
+
+				<!-- Release Year -->
+				<div class="mb-4">
+					<label
+						for="releaseYear"
+						class="block text-sm font-medium text-[var(--color-text-muted)] mb-1"
+					>
+						Release Year
+					</label>
+					<input
+						type="number"
+						id="releaseYear"
+						name="releaseYear"
+						bind:value={releaseYear}
+						min="1900"
+						max="2100"
+						class="w-full bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+						placeholder="e.g., 2023"
+					/>
+				</div>
+
+				<!-- Comment -->
+				<div class="mb-6">
+					<label for="comment" class="block text-sm font-medium text-[var(--color-text-muted)] mb-1">
+						Comment
+					</label>
+					<input
+						type="text"
+						id="comment"
+						name="comment"
+						bind:value={comment}
+						class="w-full bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+						placeholder="Optional notes"
+					/>
+				</div>
+
+				<!-- Actions -->
+				<div class="flex gap-3">
+					<button
+						type="button"
+						onclick={onClose}
+						class="flex-1 px-4 py-2.5 bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)] rounded-lg text-sm font-medium hover:bg-[var(--color-surface)] transition-colors"
+					>
+						Cancel
+					</button>
+					<button
+						type="submit"
+						class="flex-1 px-4 py-2.5 bg-[var(--color-accent)] text-white rounded-lg text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors"
+					>
+						Add {mediaTypeLabel}
+					</button>
+				</div>
+			</form>
+		</div>
+	</div>
+{/if}
+
+<style>
+	@keyframes fade-in {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+
+	@keyframes scale-in {
+		from {
+			opacity: 0;
+			transform: scale(0.95);
+		}
+		to {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+
+	.animate-fade-in {
+		animation: fade-in 0.15s ease-out;
+	}
+
+	.animate-scale-in {
+		animation: scale-in 0.15s ease-out;
+	}
+
+	.line-clamp-2 {
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+</style>

--- a/src/lib/components/media/AddMediaModal.svelte
+++ b/src/lib/components/media/AddMediaModal.svelte
@@ -158,7 +158,13 @@
 				<!-- TMDB Search -->
 				<div class="mb-4 relative">
 					<label for="search" class="block text-sm font-medium text-[var(--color-text-muted)] mb-1">
-						Search TMDB
+						Search
+						<a
+							href="https://www.themoviedb.org/"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="text-[var(--color-accent)] hover:underline"
+						>TMDB</a>
 					</label>
 					<div class="relative">
 						<input

--- a/src/lib/components/media/EditMediaModal.svelte
+++ b/src/lib/components/media/EditMediaModal.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { Media } from './types';
+
+	type Props = {
+		isOpen: boolean;
+		media: Media | null;
+		onClose: () => void;
+	};
+
+	let { isOpen, media, onClose }: Props = $props();
+
+	// Form state derived from media prop
+	let name = $state('');
+	let genre = $state('');
+	let releaseYear = $state('');
+	let comment = $state('');
+	let tmdbId = $state('');
+	let posterUrl = $state('');
+
+	// Update form when media changes
+	$effect(() => {
+		if (media) {
+			name = media.name;
+			genre = media.genre ?? '';
+			releaseYear = media.releaseYear?.toString() ?? '';
+			comment = media.comment ?? '';
+			tmdbId = media.tmdbId ?? '';
+			posterUrl = media.posterUrl ?? '';
+		}
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			onClose();
+		}
+	}
+
+	let mediaTypeLabel = $derived(media?.mediaType === 'tv' ? 'Series' : 'Movie');
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if isOpen && media}
+	<div
+		class="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in"
+		onclick={(e) => {
+			if (e.target === e.currentTarget) onClose();
+		}}
+		onkeydown={(e) => {
+			if (e.key === 'Escape') onClose();
+		}}
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="modal-title"
+		tabindex="-1"
+	>
+		<div
+			class="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-xl p-6 w-[450px] shadow-2xl animate-scale-in"
+		>
+			<h3 id="modal-title" class="text-lg font-semibold text-[var(--color-text)] mb-4">
+				Edit {mediaTypeLabel}
+			</h3>
+
+			<form
+				method="POST"
+				action="?/updateMedia"
+				use:enhance={() => {
+					return async ({ update, result }) => {
+						await update({ reset: false });
+						if (result.type === 'success') {
+							onClose();
+						}
+					};
+				}}
+			>
+				<input type="hidden" name="mediaId" value={media.id} />
+				<input type="hidden" name="tmdbId" value={tmdbId} />
+				<input type="hidden" name="posterUrl" value={posterUrl} />
+
+				<!-- Poster preview if available -->
+				{#if media.posterUrl}
+					<div class="mb-4 flex justify-center">
+						<img src={media.posterUrl} alt="" class="w-24 h-36 object-cover rounded-lg shadow-lg" />
+					</div>
+				{/if}
+
+				<!-- Name (required) -->
+				<div class="mb-4">
+					<label
+						for="edit-name"
+						class="block text-sm font-medium text-[var(--color-text-muted)] mb-1"
+					>
+						Name <span class="text-red-400">*</span>
+					</label>
+					<!-- svelte-ignore a11y_autofocus -->
+					<input
+						type="text"
+						id="edit-name"
+						name="name"
+						bind:value={name}
+						required
+						autofocus
+						class="w-full bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+					/>
+				</div>
+
+				<!-- Genre -->
+				<div class="mb-4">
+					<label
+						for="edit-genre"
+						class="block text-sm font-medium text-[var(--color-text-muted)] mb-1"
+					>
+						Genre
+					</label>
+					<input
+						type="text"
+						id="edit-genre"
+						name="genre"
+						bind:value={genre}
+						class="w-full bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+						placeholder="e.g., Drama"
+					/>
+				</div>
+
+				<!-- Release Year -->
+				<div class="mb-4">
+					<label
+						for="edit-releaseYear"
+						class="block text-sm font-medium text-[var(--color-text-muted)] mb-1"
+					>
+						Release Year
+					</label>
+					<input
+						type="number"
+						id="edit-releaseYear"
+						name="releaseYear"
+						bind:value={releaseYear}
+						min="1900"
+						max="2100"
+						class="w-full bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+					/>
+				</div>
+
+				<!-- Comment -->
+				<div class="mb-6">
+					<label
+						for="edit-comment"
+						class="block text-sm font-medium text-[var(--color-text-muted)] mb-1"
+					>
+						Comment
+					</label>
+					<input
+						type="text"
+						id="edit-comment"
+						name="comment"
+						bind:value={comment}
+						class="w-full bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg px-3 py-2 text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+					/>
+				</div>
+
+				<!-- Current Tier (read-only info) -->
+				<p class="text-xs text-[var(--color-text-muted)] mb-4">
+					Current tier: <span class="font-medium text-[var(--color-text)]">{media.tier}</span>
+					<span class="opacity-60">(drag to change)</span>
+				</p>
+
+				<!-- Actions -->
+				<div class="flex gap-3">
+					<button
+						type="button"
+						onclick={onClose}
+						class="flex-1 px-4 py-2.5 bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)] rounded-lg text-sm font-medium hover:bg-[var(--color-surface)] transition-colors"
+					>
+						Cancel
+					</button>
+					<button
+						type="submit"
+						class="flex-1 px-4 py-2.5 bg-[var(--color-accent)] text-white rounded-lg text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors"
+					>
+						Save Changes
+					</button>
+				</div>
+			</form>
+		</div>
+	</div>
+{/if}
+
+<style>
+	@keyframes fade-in {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+
+	@keyframes scale-in {
+		from {
+			opacity: 0;
+			transform: scale(0.95);
+		}
+		to {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+
+	.animate-fade-in {
+		animation: fade-in 0.15s ease-out;
+	}
+
+	.animate-scale-in {
+		animation: scale-in 0.15s ease-out;
+	}
+</style>

--- a/src/lib/components/media/MediaCard.svelte
+++ b/src/lib/components/media/MediaCard.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	import { Edit, Trash } from '$lib/components/kanban/icons';
+	import type { Media } from './types';
+
+	type Props = {
+		media: Media;
+		rank?: number;
+		onEdit?: (media: Media) => void;
+		onDelete?: (media: Media) => void;
+	};
+
+	let { media, rank, onEdit, onDelete }: Props = $props();
+
+	// Track image load state
+	let imageLoaded = $state(false);
+	let imageError = $state(false);
+</script>
+
+<div
+	class="relative w-[100px] bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg overflow-hidden hover:border-[var(--color-accent)]/50 transition-colors group cursor-grab active:cursor-grabbing"
+>
+	<!-- Action buttons (top right, on hover) -->
+	<div
+		class="absolute top-1 right-1 z-10 flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+	>
+		{#if onEdit && onDelete}
+			<button
+				type="button"
+				onclick={() => onEdit(media)}
+				class="p-1 bg-black/80 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+				title="Edit"
+			>
+				<Edit />
+			</button>
+			<button
+				type="button"
+				onclick={() => onDelete(media)}
+				class="p-1 bg-black/80 rounded text-[var(--color-text-muted)] hover:text-red-400 transition-colors"
+				title="Delete"
+			>
+				<Trash />
+			</button>
+		{/if}
+	</div>
+
+	<!-- Poster Image (portrait aspect ratio) -->
+	{#if media.posterUrl && !imageError}
+		<div class="relative w-full aspect-[2/3] bg-[var(--color-bg)] overflow-hidden">
+			<!-- Shimmer placeholder while loading -->
+			{#if !imageLoaded}
+				<div class="absolute inset-0 shimmer"></div>
+			{/if}
+			<img
+				src={media.posterUrl}
+				alt=""
+				class="w-full h-full object-cover transition-opacity duration-200"
+				class:opacity-0={!imageLoaded}
+				class:opacity-100={imageLoaded}
+				onload={() => (imageLoaded = true)}
+				onerror={() => (imageError = true)}
+			/>
+			{#if rank}
+				<span
+					class="absolute top-1 left-1 text-[10px] font-mono font-bold text-[var(--color-accent)] bg-black/90 border border-[var(--color-accent)]/50 px-1.5 py-0.5 rounded shadow-lg"
+				>
+					{rank}
+				</span>
+			{/if}
+
+			<!-- Hover overlay with title and metadata -->
+			<div
+				class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/90 via-black/70 to-transparent p-2 pt-6 opacity-0 group-hover:opacity-100 transition-opacity"
+			>
+				<h3 class="font-medium text-white text-xs leading-tight line-clamp-2">
+					{media.name}
+				</h3>
+				{#if media.genre || media.releaseYear}
+					<p class="text-[10px] text-white/70 mt-0.5">
+						{#if media.genre}{media.genre}{/if}
+						{#if media.genre && media.releaseYear} · {/if}
+						{#if media.releaseYear}{media.releaseYear}{/if}
+					</p>
+				{/if}
+			</div>
+		</div>
+	{/if}
+
+	<!-- Title (shown on hover or if no poster) -->
+	{#if !media.posterUrl || imageError}
+		<div class="p-2">
+			<div class="flex items-start gap-2">
+				{#if rank}
+					<span
+						class="text-[10px] font-mono font-bold text-[var(--color-accent)] bg-[var(--color-accent)]/15 px-1.5 py-0.5 rounded shrink-0"
+					>
+						{rank}
+					</span>
+				{/if}
+				<h3 class="font-medium text-[var(--color-text)] text-xs leading-tight line-clamp-2">
+					{media.name}
+				</h3>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.shimmer {
+		background: linear-gradient(
+			90deg,
+			var(--color-bg) 0%,
+			var(--color-surface) 50%,
+			var(--color-bg) 100%
+		);
+		background-size: 200% 100%;
+		animation: shimmer 1.5s ease-in-out infinite;
+	}
+
+	@keyframes shimmer {
+		0% {
+			background-position: 200% 0;
+		}
+		100% {
+			background-position: -200% 0;
+		}
+	}
+</style>

--- a/src/lib/components/media/TierColumn.svelte
+++ b/src/lib/components/media/TierColumn.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import { dndzone } from 'svelte-dnd-action';
+	import { flip } from 'svelte/animate';
+	import MediaCard from './MediaCard.svelte';
+	import type { Media, MediaTier, TierConfig } from './types';
+	import { TIER_CONFIGS } from './types';
+
+	type Props = {
+		tierId: MediaTier;
+		items: Media[];
+		rankOffset?: number;
+		flipDurationMs?: number;
+		onDndConsider: (
+			tierId: MediaTier,
+			e: CustomEvent<{ items: Media[] }>
+		) => void;
+		onDndFinalize: (
+			tierId: MediaTier,
+			e: CustomEvent<{ items: Media[]; info: { source: string; trigger: string } }>
+		) => void;
+		onEditMedia: (media: Media) => void;
+		onDeleteMedia: (media: Media) => void;
+	};
+
+	let {
+		tierId,
+		items,
+		rankOffset = 0,
+		flipDurationMs = 200,
+		onDndConsider,
+		onDndFinalize,
+		onEditMedia,
+		onDeleteMedia,
+	}: Props = $props();
+
+	// svelte-ignore state_referenced_locally
+	const config: TierConfig = TIER_CONFIGS[tierId];
+</script>
+
+<div class="flex-shrink-0 w-[140px] flex flex-col h-full">
+	<!-- Column Header -->
+	<div
+		class="flex items-center justify-between mb-2 px-2 py-1.5 rounded-t-lg"
+		style="background-color: {config.bgColor}"
+	>
+		<h2 class="font-bold text-lg" style="color: {config.color}">
+			{config.title}
+		</h2>
+		<span
+			class="text-xs px-2 py-0.5 rounded-full font-medium"
+			style="background-color: {config.color}30; color: {config.color}"
+		>
+			{items.length}
+		</span>
+	</div>
+
+	<!-- Drag-and-drop zone -->
+	<div
+		class="flex-1 rounded-b-lg p-1.5 space-y-1.5 overflow-y-auto min-h-[200px]"
+		style="background-color: {config.bgColor}"
+		use:dndzone={{ items, flipDurationMs, dropTargetStyle: {} }}
+		onconsider={(e) => onDndConsider(tierId, e)}
+		onfinalize={(e) => onDndFinalize(tierId, e)}
+	>
+		{#each items as item, index (item.id)}
+			<div animate:flip={{ duration: flipDurationMs }}>
+				<MediaCard
+					media={item}
+					rank={rankOffset + index + 1}
+					onEdit={onEditMedia}
+					onDelete={onDeleteMedia}
+				/>
+			</div>
+		{/each}
+
+		<!-- Empty state -->
+		{#if items.length === 0}
+			<div class="text-center py-6 text-[var(--color-text-muted)] text-xs">
+				No items
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/media/TierRow.svelte
+++ b/src/lib/components/media/TierRow.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { dndzone } from 'svelte-dnd-action';
+	import { flip } from 'svelte/animate';
+	import MediaCard from './MediaCard.svelte';
+	import type { Media, MediaTier, TierConfig } from './types';
+	import { TIER_CONFIGS } from './types';
+
+	type Props = {
+		tierId: MediaTier;
+		items: Media[];
+		rankOffset?: number;
+		flipDurationMs?: number;
+		onDndConsider: (tierId: MediaTier, e: CustomEvent<{ items: Media[] }>) => void;
+		onDndFinalize: (
+			tierId: MediaTier,
+			e: CustomEvent<{ items: Media[]; info: { source: string; trigger: string } }>
+		) => void;
+		onEditMedia: (media: Media) => void;
+		onDeleteMedia: (media: Media) => void;
+	};
+
+	let {
+		tierId,
+		items,
+		rankOffset = 0,
+		flipDurationMs = 200,
+		onDndConsider,
+		onDndFinalize,
+		onEditMedia,
+		onDeleteMedia,
+	}: Props = $props();
+
+	// svelte-ignore state_referenced_locally
+	const config: TierConfig = TIER_CONFIGS[tierId];
+</script>
+
+<div class="flex gap-2">
+	<!-- Tier Badge -->
+	<div
+		class="flex-shrink-0 w-16 flex items-center justify-center rounded-lg"
+		style="background-color: {config.bgColor}"
+	>
+		<div class="text-center">
+			<span class="text-2xl font-bold" style="color: {config.color}">
+				{config.title}
+			</span>
+			<div
+				class="text-xs mt-1 px-2 py-0.5 rounded-full font-medium"
+				style="background-color: {config.color}30; color: {config.color}"
+			>
+				{items.length}
+			</div>
+		</div>
+	</div>
+
+	<!-- Drag-and-drop zone (horizontal) -->
+	<div
+		class="flex-1 flex gap-2 items-start p-2 rounded-lg overflow-x-auto"
+		style="background-color: {config.bgColor}"
+		use:dndzone={{ items, flipDurationMs, dropTargetStyle: {}, type: 'media' }}
+		onconsider={(e) => onDndConsider(tierId, e)}
+		onfinalize={(e) => onDndFinalize(tierId, e)}
+	>
+		{#each items as item, index (item.id)}
+			<div animate:flip={{ duration: flipDurationMs }} class="flex-shrink-0">
+				<MediaCard
+					media={item}
+					rank={rankOffset + index + 1}
+					onEdit={onEditMedia}
+					onDelete={onDeleteMedia}
+				/>
+			</div>
+		{/each}
+
+		<!-- Empty state -->
+		{#if items.length === 0}
+			<div
+				class="flex-1 flex items-center justify-center text-[var(--color-text-muted)] text-sm py-4"
+			>
+				Drop here
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/media/index.ts
+++ b/src/lib/components/media/index.ts
@@ -1,0 +1,6 @@
+export { default as MediaCard } from './MediaCard.svelte';
+export { default as TierColumn } from './TierColumn.svelte';
+export { default as TierRow } from './TierRow.svelte';
+export { default as AddMediaModal } from './AddMediaModal.svelte';
+export { default as EditMediaModal } from './EditMediaModal.svelte';
+export * from './types';

--- a/src/lib/components/media/types.ts
+++ b/src/lib/components/media/types.ts
@@ -1,0 +1,25 @@
+import { type Tier, type TierConfig, TIER_CONFIGS, TIER_ORDER } from '../shared/tiers';
+
+// Re-export shared tier types
+export type MediaTier = Tier;
+export type { TierConfig };
+export { TIER_CONFIGS, TIER_ORDER };
+
+export type MediaType = 'tv' | 'movie';
+
+export type Media = {
+	id: number;
+	name: string;
+	mediaType: string;
+	tier: string;
+	genre: string | null;
+	releaseYear: number | null;
+	tmdbId: string | null;
+	posterUrl: string | null;
+	comment: string | null;
+	sortOrder: number;
+	createdAt: string;
+	updatedAt: string;
+};
+
+export type MediaByTier = Record<MediaTier, Media[]>;

--- a/src/lib/components/shared/tiers.ts
+++ b/src/lib/components/shared/tiers.ts
@@ -1,0 +1,27 @@
+// Shared tier ranking system used by games and media
+export type Tier = 'S' | 'A+' | 'A' | 'A-' | 'B+' | 'B' | 'B-' | 'C+' | 'C';
+
+export type TierConfig = {
+	id: Tier;
+	title: string;
+	color: string;
+	bgColor: string;
+};
+
+export const TIER_CONFIGS: Record<Tier, TierConfig> = {
+	S: { id: 'S', title: 'S', color: '#fbbf24', bgColor: 'rgba(251, 191, 36, 0.15)' },
+	'A+': { id: 'A+', title: 'A+', color: '#a3e635', bgColor: 'rgba(163, 230, 53, 0.15)' },
+	A: { id: 'A', title: 'A', color: '#22c55e', bgColor: 'rgba(34, 197, 94, 0.15)' },
+	'A-': { id: 'A-', title: 'A-', color: '#34d399', bgColor: 'rgba(52, 211, 153, 0.15)' },
+	'B+': { id: 'B+', title: 'B+', color: '#38bdf8', bgColor: 'rgba(56, 189, 248, 0.15)' },
+	B: { id: 'B', title: 'B', color: '#60a5fa', bgColor: 'rgba(96, 165, 250, 0.15)' },
+	'B-': { id: 'B-', title: 'B-', color: '#818cf8', bgColor: 'rgba(129, 140, 248, 0.15)' },
+	'C+': { id: 'C+', title: 'C+', color: '#a78bfa', bgColor: 'rgba(167, 139, 250, 0.15)' },
+	C: { id: 'C', title: 'C', color: '#c084fc', bgColor: 'rgba(192, 132, 252, 0.15)' },
+};
+
+export const TIER_ORDER: Tier[] = ['S', 'A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C'];
+
+export function isValidTier(tier: string): tier is Tier {
+	return TIER_ORDER.includes(tier as Tier);
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -179,6 +179,34 @@ export type VideoGame = typeof videoGames.$inferSelect;
 export type NewVideoGame = typeof videoGames.$inferInsert;
 
 // ============================================
+// Media (TV Shows & Movies) Tables
+// ============================================
+
+export const MEDIA_TYPES = ['tv', 'movie'] as const;
+export type MediaType = (typeof MEDIA_TYPES)[number];
+
+export const MEDIA_TIERS = ['S', 'A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C'] as const;
+export type MediaTier = (typeof MEDIA_TIERS)[number];
+
+export const media = sqliteTable('media', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+  mediaType: text('media_type').notNull(), // 'tv' | 'movie'
+  tier: text('tier').notNull(), // 'S' | 'A+' | 'A' | 'A-' | 'B+' | 'B' | 'B-' | 'C+' | 'C'
+  genre: text('genre'),
+  releaseYear: integer('release_year'),
+  tmdbId: text('tmdb_id'), // For TMDB API integration
+  posterUrl: text('poster_url'), // TMDB poster URL
+  comment: text('comment'),
+  sortOrder: integer('sort_order').notNull().default(0), // Per-tier ordering (separate per mediaType)
+  createdAt: text('created_at').notNull().$defaultFn(() => new Date().toISOString()),
+  updatedAt: text('updated_at').notNull().$defaultFn(() => new Date().toISOString()),
+});
+
+export type Media = typeof media.$inferSelect;
+export type NewMedia = typeof media.$inferInsert;
+
+// ============================================
 // OAuth Tokens (for Fitbit, etc.)
 // ============================================
 

--- a/src/lib/services/media.ts
+++ b/src/lib/services/media.ts
@@ -1,0 +1,217 @@
+import { db } from '$lib/db';
+import { media, MEDIA_TIERS, MEDIA_TYPES, type MediaTier, type MediaType } from '$lib/db/schema';
+import { eq, and, asc, max } from 'drizzle-orm';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type MediaData = {
+	id: number;
+	name: string;
+	mediaType: string;
+	tier: string;
+	genre: string | null;
+	releaseYear: number | null;
+	tmdbId: string | null;
+	posterUrl: string | null;
+	comment: string | null;
+	sortOrder: number;
+	createdAt: string;
+	updatedAt: string;
+};
+
+export type MediaByTier = Record<MediaTier, MediaData[]>;
+
+export type CreateMediaInput = {
+	name: string;
+	mediaType: MediaType;
+	tier: MediaTier;
+	genre?: string | null;
+	releaseYear?: number | null;
+	tmdbId?: string | null;
+	posterUrl?: string | null;
+	comment?: string | null;
+};
+
+export type UpdateMediaInput = {
+	mediaId: number;
+	name: string;
+	genre?: string | null;
+	releaseYear?: number | null;
+	tmdbId?: string | null;
+	posterUrl?: string | null;
+	comment?: string | null;
+};
+
+export type MoveMediaInput = {
+	mediaId: number;
+	tier: MediaTier;
+	sortOrder: number;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Query Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch all media of a specific type grouped by tier, sorted by sortOrder within each tier
+ */
+export async function getMediaByTier(mediaType: MediaType): Promise<MediaByTier> {
+	const allMedia = await db
+		.select()
+		.from(media)
+		.where(eq(media.mediaType, mediaType))
+		.orderBy(asc(media.sortOrder));
+
+	// Initialize empty arrays for each tier
+	const result: MediaByTier = {
+		S: [],
+		'A+': [],
+		A: [],
+		'A-': [],
+		'B+': [],
+		B: [],
+		'B-': [],
+		'C+': [],
+		C: [],
+	};
+
+	// Group media by tier
+	for (const item of allMedia) {
+		const tier = item.tier as MediaTier;
+		if (tier in result) {
+			result[tier].push(item);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Get a single media item by ID
+ */
+export async function getMediaById(mediaId: number): Promise<MediaData | null> {
+	const item = await db.select().from(media).where(eq(media.id, mediaId)).get();
+
+	return item ?? null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Media Mutations
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Create a new media item (appends to end of specified tier)
+ */
+export async function createMedia(input: CreateMediaInput): Promise<{ mediaId: number }> {
+	const { name, mediaType, tier, genre, releaseYear, tmdbId, posterUrl, comment } = input;
+
+	// Get the max sortOrder for the target tier AND mediaType
+	const maxOrder = await db
+		.select({ max: max(media.sortOrder) })
+		.from(media)
+		.where(and(eq(media.tier, tier), eq(media.mediaType, mediaType)))
+		.get();
+
+	const newSortOrder = (maxOrder?.max ?? -1) + 1;
+
+	const result = await db
+		.insert(media)
+		.values({
+			name: name.trim(),
+			mediaType,
+			tier,
+			genre: genre?.trim() || null,
+			releaseYear: releaseYear ?? null,
+			tmdbId: tmdbId?.trim() || null,
+			posterUrl: posterUrl?.trim() || null,
+			comment: comment?.trim() || null,
+			sortOrder: newSortOrder,
+		})
+		.returning({ id: media.id });
+
+	return { mediaId: result[0].id };
+}
+
+/**
+ * Update a media item's details (not tier or order - use moveMedia for that)
+ */
+export async function updateMedia(input: UpdateMediaInput): Promise<void> {
+	const { mediaId, name, genre, releaseYear, tmdbId, posterUrl, comment } = input;
+
+	await db
+		.update(media)
+		.set({
+			name: name.trim(),
+			genre: genre?.trim() || null,
+			releaseYear: releaseYear ?? null,
+			tmdbId: tmdbId?.trim() || null,
+			posterUrl: posterUrl?.trim() || null,
+			comment: comment?.trim() || null,
+			updatedAt: new Date().toISOString(),
+		})
+		.where(eq(media.id, mediaId));
+}
+
+/**
+ * Delete a media item
+ */
+export async function deleteMedia(mediaId: number): Promise<void> {
+	await db.delete(media).where(eq(media.id, mediaId));
+}
+
+/**
+ * Move a media item to a different tier and/or position
+ */
+export async function moveMedia(input: MoveMediaInput): Promise<void> {
+	const { mediaId, tier, sortOrder } = input;
+
+	await db
+		.update(media)
+		.set({
+			tier,
+			sortOrder,
+			updatedAt: new Date().toISOString(),
+		})
+		.where(eq(media.id, mediaId));
+}
+
+/**
+ * Reorder media within a tier (updates sortOrder for all items in the list)
+ */
+export async function reorderTier(mediaIds: number[]): Promise<void> {
+	for (let i = 0; i < mediaIds.length; i++) {
+		await db
+			.update(media)
+			.set({ sortOrder: i, updatedAt: new Date().toISOString() })
+			.where(eq(media.id, mediaIds[i]));
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function isValidTier(tier: string): tier is MediaTier {
+	return MEDIA_TIERS.includes(tier as MediaTier);
+}
+
+export function isValidMediaType(type: string): type is MediaType {
+	return MEDIA_TYPES.includes(type as MediaType);
+}
+
+export function parseMediaId(value: string | null): number | null {
+	if (!value) return null;
+	const parsed = parseInt(value, 10);
+	return isNaN(parsed) ? null : parsed;
+}
+
+export function parseYear(value: string | null): number | null {
+	if (!value) return null;
+	const parsed = parseInt(value, 10);
+	if (isNaN(parsed)) return null;
+	// Sanity check: valid year range
+	if (parsed < 1900 || parsed > 2100) return null;
+	return parsed;
+}

--- a/src/lib/services/tmdb.ts
+++ b/src/lib/services/tmdb.ts
@@ -1,0 +1,276 @@
+import { env } from '$env/dynamic/private';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type TmdbSearchResult = {
+	id: number;
+	name: string;
+	releaseYear: number | null;
+	posterUrl: string | null;
+	overview: string;
+	genres: string[];
+};
+
+export type TmdbMediaDetails = {
+	id: number;
+	name: string;
+	releaseYear: number | null;
+	posterUrl: string | null;
+	overview: string;
+	genres: string[];
+};
+
+type TmdbTvResult = {
+	id: number;
+	name: string;
+	first_air_date?: string;
+	poster_path?: string | null;
+	overview?: string;
+	genre_ids?: number[];
+};
+
+type TmdbMovieResult = {
+	id: number;
+	title: string;
+	release_date?: string;
+	poster_path?: string | null;
+	overview?: string;
+	genre_ids?: number[];
+};
+
+type TmdbGenre = {
+	id: number;
+	name: string;
+};
+
+// TMDB genre mappings (cached to avoid extra API calls)
+const TV_GENRES: Record<number, string> = {
+	10759: 'Action & Adventure',
+	16: 'Animation',
+	35: 'Comedy',
+	80: 'Crime',
+	99: 'Documentary',
+	18: 'Drama',
+	10751: 'Family',
+	10762: 'Kids',
+	9648: 'Mystery',
+	10763: 'News',
+	10764: 'Reality',
+	10765: 'Sci-Fi & Fantasy',
+	10766: 'Soap',
+	10767: 'Talk',
+	10768: 'War & Politics',
+	37: 'Western',
+};
+
+const MOVIE_GENRES: Record<number, string> = {
+	28: 'Action',
+	12: 'Adventure',
+	16: 'Animation',
+	35: 'Comedy',
+	80: 'Crime',
+	99: 'Documentary',
+	18: 'Drama',
+	10751: 'Family',
+	14: 'Fantasy',
+	36: 'History',
+	27: 'Horror',
+	10402: 'Music',
+	9648: 'Mystery',
+	10749: 'Romance',
+	878: 'Science Fiction',
+	10770: 'TV Movie',
+	53: 'Thriller',
+	10752: 'War',
+	37: 'Western',
+};
+
+const POSTER_BASE_URL = 'https://image.tmdb.org/t/p/w342';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// API Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getApiKey(): string | null {
+	return env.TMDB_API_KEY || null;
+}
+
+function extractYear(dateString?: string): number | null {
+	if (!dateString) return null;
+	const year = parseInt(dateString.substring(0, 4), 10);
+	return isNaN(year) ? null : year;
+}
+
+function getPosterUrl(posterPath?: string | null): string | null {
+	if (!posterPath) return null;
+	return `${POSTER_BASE_URL}${posterPath}`;
+}
+
+function mapGenreIds(genreIds: number[] | undefined, genreMap: Record<number, string>): string[] {
+	if (!genreIds) return [];
+	return genreIds.map((id) => genreMap[id]).filter((name): name is string => !!name);
+}
+
+/**
+ * Search for TV shows by title
+ */
+export async function searchTvShows(query: string): Promise<TmdbSearchResult[]> {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		console.warn('TMDB_API_KEY not configured');
+		return [];
+	}
+
+	try {
+		const url = new URL('https://api.themoviedb.org/3/search/tv');
+		url.searchParams.set('api_key', apiKey);
+		url.searchParams.set('query', query);
+		url.searchParams.set('include_adult', 'false');
+
+		const response = await fetch(url.toString());
+		if (!response.ok) {
+			console.error('TMDB search failed:', response.status, response.statusText);
+			return [];
+		}
+
+		const data = (await response.json()) as { results: TmdbTvResult[] };
+
+		return data.results.slice(0, 10).map((result) => ({
+			id: result.id,
+			name: result.name,
+			releaseYear: extractYear(result.first_air_date),
+			posterUrl: getPosterUrl(result.poster_path),
+			overview: result.overview || '',
+			genres: mapGenreIds(result.genre_ids, TV_GENRES),
+		}));
+	} catch (error) {
+		console.error('TMDB search error:', error);
+		return [];
+	}
+}
+
+/**
+ * Search for movies by title
+ */
+export async function searchMovies(query: string): Promise<TmdbSearchResult[]> {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		console.warn('TMDB_API_KEY not configured');
+		return [];
+	}
+
+	try {
+		const url = new URL('https://api.themoviedb.org/3/search/movie');
+		url.searchParams.set('api_key', apiKey);
+		url.searchParams.set('query', query);
+		url.searchParams.set('include_adult', 'false');
+
+		const response = await fetch(url.toString());
+		if (!response.ok) {
+			console.error('TMDB search failed:', response.status, response.statusText);
+			return [];
+		}
+
+		const data = (await response.json()) as { results: TmdbMovieResult[] };
+
+		return data.results.slice(0, 10).map((result) => ({
+			id: result.id,
+			name: result.title,
+			releaseYear: extractYear(result.release_date),
+			posterUrl: getPosterUrl(result.poster_path),
+			overview: result.overview || '',
+			genres: mapGenreIds(result.genre_ids, MOVIE_GENRES),
+		}));
+	} catch (error) {
+		console.error('TMDB search error:', error);
+		return [];
+	}
+}
+
+/**
+ * Get detailed info for a TV show by TMDB ID
+ */
+export async function getTvShowDetails(tmdbId: number): Promise<TmdbMediaDetails | null> {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		console.warn('TMDB_API_KEY not configured');
+		return null;
+	}
+
+	try {
+		const url = new URL(`https://api.themoviedb.org/3/tv/${tmdbId}`);
+		url.searchParams.set('api_key', apiKey);
+
+		const response = await fetch(url.toString());
+		if (!response.ok) {
+			console.error('TMDB details failed:', response.status, response.statusText);
+			return null;
+		}
+
+		const data = (await response.json()) as {
+			id: number;
+			name: string;
+			first_air_date?: string;
+			poster_path?: string | null;
+			overview?: string;
+			genres?: TmdbGenre[];
+		};
+
+		return {
+			id: data.id,
+			name: data.name,
+			releaseYear: extractYear(data.first_air_date),
+			posterUrl: getPosterUrl(data.poster_path),
+			overview: data.overview || '',
+			genres: data.genres?.map((g) => g.name) || [],
+		};
+	} catch (error) {
+		console.error('TMDB details error:', error);
+		return null;
+	}
+}
+
+/**
+ * Get detailed info for a movie by TMDB ID
+ */
+export async function getMovieDetails(tmdbId: number): Promise<TmdbMediaDetails | null> {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		console.warn('TMDB_API_KEY not configured');
+		return null;
+	}
+
+	try {
+		const url = new URL(`https://api.themoviedb.org/3/movie/${tmdbId}`);
+		url.searchParams.set('api_key', apiKey);
+
+		const response = await fetch(url.toString());
+		if (!response.ok) {
+			console.error('TMDB details failed:', response.status, response.statusText);
+			return null;
+		}
+
+		const data = (await response.json()) as {
+			id: number;
+			title: string;
+			release_date?: string;
+			poster_path?: string | null;
+			overview?: string;
+			genres?: TmdbGenre[];
+		};
+
+		return {
+			id: data.id,
+			name: data.title,
+			releaseYear: extractYear(data.release_date),
+			posterUrl: getPosterUrl(data.poster_path),
+			overview: data.overview || '',
+			genres: data.genres?.map((g) => g.name) || [],
+		};
+	} catch (error) {
+		console.error('TMDB details error:', error);
+		return null;
+	}
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,7 +12,7 @@
     { href: '/meal-prep', label: 'Meal Prep', enabled: true },
     { href: '/shopping', label: 'Shopping', enabled: true },
     { href: '/games', label: 'Games', enabled: true },
-    { href: '/media', label: 'Media', enabled: false },
+    { href: '/media', label: 'Media', enabled: true },
     { href: '/tasks', label: 'Tasks', enabled: true },
   ];
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -86,13 +86,16 @@
       <p class="text-[var(--color-text-muted)]">Kanban-style shopping list with drag-and-drop.</p>
     </a>
 
-    <div class="p-6 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg opacity-50">
+    <a
+      href="/media"
+      class="block p-6 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg hover:border-[var(--color-accent)] hover:bg-[var(--color-surface-hover)] hover-glow transition-all"
+    >
       <h2 class="text-xl font-semibold mb-2 flex items-center gap-2">
         <img src="/icon-media.svg" alt="" class="w-6 h-6" />
-        Media Queue
+        Media
       </h2>
-      <p class="text-[var(--color-text-muted)]">Coming soon...</p>
-    </div>
+      <p class="text-[var(--color-text-muted)]">Tier list for ranking TV series and movies.</p>
+    </a>
 
     <a
       href="/tasks"

--- a/src/routes/api/tmdb/search/movie/+server.ts
+++ b/src/routes/api/tmdb/search/movie/+server.ts
@@ -1,0 +1,14 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { searchMovies } from '$lib/services/tmdb';
+
+export const GET: RequestHandler = async ({ url }) => {
+	const query = url.searchParams.get('query');
+
+	if (!query || query.length < 2) {
+		return json([]);
+	}
+
+	const results = await searchMovies(query);
+	return json(results);
+};

--- a/src/routes/api/tmdb/search/tv/+server.ts
+++ b/src/routes/api/tmdb/search/tv/+server.ts
@@ -1,0 +1,14 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { searchTvShows } from '$lib/services/tmdb';
+
+export const GET: RequestHandler = async ({ url }) => {
+	const query = url.searchParams.get('query');
+
+	if (!query || query.length < 2) {
+		return json([]);
+	}
+
+	const results = await searchTvShows(query);
+	return json(results);
+};

--- a/src/routes/media/+page.server.ts
+++ b/src/routes/media/+page.server.ts
@@ -1,0 +1,160 @@
+import type { PageServerLoad, Actions } from './$types';
+import {
+	getMediaByTier,
+	createMedia,
+	updateMedia,
+	deleteMedia,
+	moveMedia,
+	reorderTier,
+	isValidTier,
+	isValidMediaType,
+	parseMediaId,
+	parseYear,
+} from '$lib/services/media';
+import type { MediaType } from '$lib/db/schema';
+
+export const load: PageServerLoad = async ({ url }) => {
+	// Get media type from query param, default to 'tv'
+	const mediaTypeParam = url.searchParams.get('type');
+	const mediaType: MediaType =
+		mediaTypeParam === 'movie' || mediaTypeParam === 'tv' ? mediaTypeParam : 'tv';
+
+	const mediaByTier = await getMediaByTier(mediaType);
+
+	return { mediaByTier, mediaType };
+};
+
+export const actions: Actions = {
+	createMedia: async ({ request }) => {
+		const formData = await request.formData();
+		const name = formData.get('name') as string;
+		const mediaType = formData.get('mediaType') as string;
+		const tier = formData.get('tier') as string;
+		const genre = formData.get('genre') as string | null;
+		const releaseYearStr = formData.get('releaseYear') as string | null;
+		const comment = formData.get('comment') as string | null;
+		const tmdbId = formData.get('tmdbId') as string | null;
+		const posterUrl = formData.get('posterUrl') as string | null;
+
+		if (!name?.trim()) {
+			return { success: false, error: 'Name is required' };
+		}
+
+		if (!isValidMediaType(mediaType)) {
+			return { success: false, error: 'Invalid media type' };
+		}
+
+		if (!isValidTier(tier)) {
+			return { success: false, error: 'Invalid tier' };
+		}
+
+		const result = await createMedia({
+			name,
+			mediaType,
+			tier,
+			genre,
+			releaseYear: parseYear(releaseYearStr),
+			comment,
+			tmdbId,
+			posterUrl,
+		});
+
+		return {
+			success: true,
+			media: {
+				id: result.mediaId,
+				name,
+				mediaType,
+				tier,
+				genre,
+				releaseYear: parseYear(releaseYearStr),
+				comment,
+				tmdbId,
+				posterUrl,
+				sortOrder: 0,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+		};
+	},
+
+	updateMedia: async ({ request }) => {
+		const formData = await request.formData();
+		const mediaId = parseMediaId(formData.get('mediaId') as string);
+		const name = formData.get('name') as string;
+		const genre = formData.get('genre') as string | null;
+		const releaseYearStr = formData.get('releaseYear') as string | null;
+		const comment = formData.get('comment') as string | null;
+		const tmdbId = formData.get('tmdbId') as string | null;
+		const posterUrl = formData.get('posterUrl') as string | null;
+
+		if (!mediaId) {
+			return { success: false, error: 'Invalid media ID' };
+		}
+
+		if (!name?.trim()) {
+			return { success: false, error: 'Name is required' };
+		}
+
+		await updateMedia({
+			mediaId,
+			name,
+			genre,
+			releaseYear: parseYear(releaseYearStr),
+			comment,
+			tmdbId,
+			posterUrl,
+		});
+
+		return { success: true };
+	},
+
+	deleteMedia: async ({ request }) => {
+		const formData = await request.formData();
+		const mediaId = parseMediaId(formData.get('mediaId') as string);
+
+		if (!mediaId) {
+			return { success: false, error: 'Invalid media ID' };
+		}
+
+		await deleteMedia(mediaId);
+		return { success: true };
+	},
+
+	moveMedia: async ({ request }) => {
+		const formData = await request.formData();
+		const mediaId = parseMediaId(formData.get('mediaId') as string);
+		const tier = formData.get('tier') as string;
+		const sortOrder = parseInt(formData.get('sortOrder') as string) || 0;
+
+		if (!mediaId) {
+			return { success: false, error: 'Invalid media ID' };
+		}
+
+		if (!isValidTier(tier)) {
+			return { success: false, error: 'Invalid tier' };
+		}
+
+		await moveMedia({ mediaId, tier, sortOrder });
+		return { success: true };
+	},
+
+	reorderTier: async ({ request }) => {
+		const formData = await request.formData();
+		const mediaIdsJson = formData.get('mediaIds') as string;
+
+		if (!mediaIdsJson) {
+			return { success: false, error: 'No media IDs provided' };
+		}
+
+		let mediaIds: number[];
+		try {
+			mediaIds = JSON.parse(mediaIdsJson);
+		} catch {
+			return { success: false, error: 'Invalid media IDs format' };
+		}
+
+		await reorderTier(mediaIds);
+		return { success: true };
+	},
+};

--- a/src/routes/media/+page.svelte
+++ b/src/routes/media/+page.svelte
@@ -1,0 +1,286 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { goto } from '$app/navigation';
+	import { SOURCES, TRIGGERS } from 'svelte-dnd-action';
+	import { ConfirmModal } from '$lib/components/kanban';
+	import {
+		TierRow,
+		AddMediaModal,
+		EditMediaModal,
+		TIER_ORDER,
+		type Media,
+		type MediaTier,
+		type MediaType,
+	} from '$lib/components/media';
+
+	let { data }: { data: PageData } = $props();
+
+	// ─────────────────────────────────────────────────────────────────────────────
+	// Media Type State
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	let currentMediaType = $state<MediaType>(data.mediaType as MediaType);
+
+	// When media type changes, navigate to update URL and reload data
+	async function handleMediaTypeChange(newType: MediaType) {
+		if (newType === currentMediaType) return;
+		currentMediaType = newType;
+		await goto(`/media?type=${newType}`, { invalidateAll: true });
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────
+	// Media State (per tier)
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	// Local state for each tier - initialized from server data
+	// svelte-ignore state_referenced_locally
+	let tierMedia = $state<Record<MediaTier, Media[]>>({
+		S: [...data.mediaByTier.S] as Media[],
+		'A+': [...data.mediaByTier['A+']] as Media[],
+		A: [...data.mediaByTier.A] as Media[],
+		'A-': [...data.mediaByTier['A-']] as Media[],
+		'B+': [...data.mediaByTier['B+']] as Media[],
+		B: [...data.mediaByTier.B] as Media[],
+		'B-': [...data.mediaByTier['B-']] as Media[],
+		'C+': [...data.mediaByTier['C+']] as Media[],
+		C: [...data.mediaByTier.C] as Media[],
+	});
+
+	// Track last known data reference to detect actual page navigations/reloads
+	// svelte-ignore state_referenced_locally
+	let lastDataRef = data;
+
+	// Only sync when the data object itself changes (navigation/reload)
+	$effect.pre(() => {
+		if (data !== lastDataRef) {
+			lastDataRef = data;
+			currentMediaType = data.mediaType as MediaType;
+			tierMedia = {
+				S: [...data.mediaByTier.S] as Media[],
+				'A+': [...data.mediaByTier['A+']] as Media[],
+				A: [...data.mediaByTier.A] as Media[],
+				'A-': [...data.mediaByTier['A-']] as Media[],
+				'B+': [...data.mediaByTier['B+']] as Media[],
+				B: [...data.mediaByTier.B] as Media[],
+				'B-': [...data.mediaByTier['B-']] as Media[],
+				'C+': [...data.mediaByTier['C+']] as Media[],
+				C: [...data.mediaByTier.C] as Media[],
+			};
+		}
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────────
+	// UI State
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	let showAddModal = $state(false);
+	let editingMedia = $state<Media | null>(null);
+	let mediaToDelete = $state<Media | null>(null);
+
+	const flipDurationMs = 200;
+
+	// Total count
+	let totalItems = $derived(
+		Object.values(tierMedia).reduce((sum, items) => sum + items.length, 0)
+	);
+
+	// Calculate rank offsets for each tier
+	let tierRankOffsets = $derived(() => {
+		const offsets: Record<MediaTier, number> = {} as Record<MediaTier, number>;
+		let cumulative = 0;
+		for (const tier of TIER_ORDER) {
+			offsets[tier] = cumulative;
+			cumulative += tierMedia[tier].length;
+		}
+		return offsets;
+	});
+
+	let mediaTypeLabel = $derived(currentMediaType === 'tv' ? 'Series' : 'Movies');
+	let mediaTypeSingular = $derived(currentMediaType === 'tv' ? 'Series' : 'Movie');
+
+	// ─────────────────────────────────────────────────────────────────────────────
+	// Edit/Delete Handlers
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	function handleEditMedia(item: Media) {
+		editingMedia = item;
+	}
+
+	function handleDeleteMedia(item: Media) {
+		mediaToDelete = item;
+	}
+
+	function closeEditModal() {
+		editingMedia = null;
+	}
+
+	function closeDeleteModal() {
+		mediaToDelete = null;
+	}
+
+	function closeAddModal() {
+		showAddModal = false;
+	}
+
+	function handleMediaAdded() {
+		// Invalidate to reload data
+		goto(`/media?type=${currentMediaType}`, { invalidateAll: true });
+		closeAddModal();
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────
+	// Drag and Drop Handlers
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	function handleDndConsider(tierId: MediaTier, e: CustomEvent<{ items: Media[] }>) {
+		tierMedia[tierId] = e.detail.items;
+	}
+
+	function handleDndFinalize(
+		tierId: MediaTier,
+		e: CustomEvent<{ items: Media[]; info: { source: string; trigger: string } }>
+	) {
+		const { items, info } = e.detail;
+		tierMedia[tierId] = items;
+
+		// Only persist if this was a drop (not just a cancel)
+		if (info.source === SOURCES.POINTER && info.trigger === TRIGGERS.DROPPED_INTO_ZONE) {
+			persistTierOrder(tierId, items);
+		}
+	}
+
+	// ─────────────────────────────────────────────────────────────────────────────
+	// Persistence
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	async function persistTierOrder(tierId: MediaTier, items: Media[]) {
+		// Move items that changed tiers
+		for (let i = 0; i < items.length; i++) {
+			const item = items[i];
+			if (item.tier !== tierId) {
+				const formData = new FormData();
+				formData.append('mediaId', String(item.id));
+				formData.append('tier', tierId);
+				formData.append('sortOrder', String(i));
+
+				await fetch('?/moveMedia', {
+					method: 'POST',
+					body: formData,
+				});
+
+				// Update local tier
+				item.tier = tierId;
+			}
+		}
+
+		// Reorder all items in the tier
+		if (items.length > 0) {
+			const formData = new FormData();
+			formData.append('mediaIds', JSON.stringify(items.map((item) => item.id)));
+
+			await fetch('?/reorderTier', {
+				method: 'POST',
+				body: formData,
+			});
+		}
+	}
+</script>
+
+<div class="h-[calc(100vh-120px)] flex flex-col">
+	<!-- Header -->
+	<div class="flex items-center justify-between mb-4">
+		<div class="flex items-center gap-4">
+			<h1 class="text-2xl font-bold flex items-center gap-3">
+				<img src="/icon-media.svg" alt="" class="w-7 h-7" />
+				Media
+			</h1>
+
+			<!-- Media Type Toggle -->
+			<div class="flex bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg p-1">
+				<button
+					type="button"
+					onclick={() => handleMediaTypeChange('tv')}
+					class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors"
+					class:bg-[var(--color-accent)]={currentMediaType === 'tv'}
+					class:text-white={currentMediaType === 'tv'}
+					class:text-[var(--color-text-muted)]={currentMediaType !== 'tv'}
+					class:hover:text-[var(--color-text)]={currentMediaType !== 'tv'}
+				>
+					Series
+				</button>
+				<button
+					type="button"
+					onclick={() => handleMediaTypeChange('movie')}
+					class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors"
+					class:bg-[var(--color-accent)]={currentMediaType === 'movie'}
+					class:text-white={currentMediaType === 'movie'}
+					class:text-[var(--color-text-muted)]={currentMediaType !== 'movie'}
+					class:hover:text-[var(--color-text)]={currentMediaType !== 'movie'}
+				>
+					Movies
+				</button>
+			</div>
+
+			<span class="text-sm text-[var(--color-text-muted)]">
+				({totalItems} {totalItems === 1 ? mediaTypeSingular.toLowerCase() : mediaTypeLabel.toLowerCase()})
+			</span>
+		</div>
+
+		<button
+			type="button"
+			onclick={() => (showAddModal = true)}
+			class="px-4 py-2 bg-[var(--color-accent)] text-white rounded-lg text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors flex items-center gap-2"
+		>
+			<span class="text-lg">+</span>
+			Add {mediaTypeSingular}
+		</button>
+	</div>
+
+	<!-- Tier Board (vertical stack of horizontal rows) -->
+	<div class="flex-1 flex flex-col gap-2 overflow-y-auto pb-4">
+		{#each TIER_ORDER as tierId}
+			<TierRow
+				{tierId}
+				items={tierMedia[tierId]}
+				rankOffset={tierRankOffsets()[tierId]}
+				{flipDurationMs}
+				onDndConsider={handleDndConsider}
+				onDndFinalize={handleDndFinalize}
+				onEditMedia={handleEditMedia}
+				onDeleteMedia={handleDeleteMedia}
+			/>
+		{/each}
+	</div>
+
+	<!-- Footer hint -->
+	<div class="text-xs text-[var(--color-text-muted)]">
+		Drag {mediaTypeLabel.toLowerCase()} between tiers to change ratings
+	</div>
+</div>
+
+<!-- Add Media Modal -->
+<AddMediaModal
+	isOpen={showAddModal}
+	mediaType={currentMediaType}
+	onClose={closeAddModal}
+	onSuccess={handleMediaAdded}
+/>
+
+<!-- Edit Media Modal -->
+<EditMediaModal
+	isOpen={editingMedia !== null}
+	media={editingMedia}
+	onClose={closeEditModal}
+/>
+
+<!-- Delete Confirmation Modal -->
+<ConfirmModal
+	isOpen={mediaToDelete !== null}
+	title="Delete {mediaTypeSingular}"
+	message="Are you sure you want to delete this {mediaTypeSingular.toLowerCase()}? This action cannot be undone."
+	confirmText="Delete"
+	cancelText="Cancel"
+	formAction="?/deleteMedia"
+	formData={mediaToDelete ? { mediaId: mediaToDelete.id } : undefined}
+	onCancel={closeDeleteModal}
+/>


### PR DESCRIPTION
## Summary
- New `/media` page with Series/Movies toggle (defaults to Series)
- Same S-through-C tier system as games, with shared tier constants extracted to `src/lib/components/shared/tiers.ts`
- TMDB API integration for search and auto-fill (poster, year, genre)
- Horizontal tier rows with portrait poster cards (100px wide)
- Hover overlay shows title and metadata on cards
- Full drag-and-drop support for reordering within tiers and moving between tiers
- Activated Media card on home screen with icon

## Test plan
- [ ] Navigate to /media and verify Series/Movies toggle works
- [ ] Add a series via TMDB search - verify poster, year, genre auto-fill
- [ ] Add a movie and verify it appears separately from series
- [ ] Drag items between tiers and verify persistence
- [ ] Hover over cards to see title/metadata overlay
- [ ] Edit and delete media items
- [ ] Verify home screen Media card links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)