### PR TITLE
Restyle /retirement pages to match ghost's design language

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -45,6 +45,36 @@ Ghost uses a **cyberpunk/hologram aesthetic** - dark backgrounds with cyan accen
 | `--color-glow` | `rgba(6, 182, 212, 0.15)` | Subtle glow effects |
 | `--color-glow-strong` | `rgba(6, 182, 212, 0.25)` | Stronger glow effects |
 
+### Status Colors
+
+| Variable | Value | Usage |
+|----------|-------|-------|
+| `--color-success` | `#0ca30c` | Positive states (funded plan, save actions) |
+| `--color-error` | `#e66767` | Errors, warnings, destructive actions |
+
+Status colors are reserved for state — never use them as chart series colors.
+
+### Data-Viz Series Colors
+
+For multi-series charts (`/analytics`, `/retirement`). Slots are assigned in
+**fixed order** (series 1 always gets `--viz-1`, etc.) and never cycled or
+reused for status. The set is validated colorblind-safe against
+`--color-surface` — if you change a hue, re-validate the whole set as adjacent
+pairs, don't eyeball it.
+
+| Variable | Value | Hue |
+|----------|-------|-----|
+| `--color-viz-1` | `#0891b2` | cyan (brand family) |
+| `--color-viz-2` | `#d95926` | orange |
+| `--color-viz-3` | `#9085e9` | violet |
+| `--color-viz-4` | `#c98500` | yellow |
+| `--color-viz-5` | `#d55181` | magenta |
+
+Charts with more than five series fold the tail into an "Everything else"
+series rather than generating new hues. Legends are always present for two or
+more series, and text (labels, values) stays in text tokens, never the series
+color.
+
 ## Visual Elements
 
 ### Background

--- a/src/app.css
+++ b/src/app.css
@@ -20,6 +20,19 @@
   /* Glow effect for hover states */
   --color-glow: rgba(6, 182, 212, 0.15);
   --color-glow-strong: rgba(6, 182, 212, 0.25);
+
+  /* Status */
+  --color-success: #0ca30c;
+  --color-error: #e66767;
+
+  /* Data-viz series — categorical, in fixed slot order (never cycled).
+     Validated CVD-safe as a set against --color-surface; keep the order and
+     re-validate if a hue changes. */
+  --color-viz-1: #0891b2;
+  --color-viz-2: #d95926;
+  --color-viz-3: #9085e9;
+  --color-viz-4: #c98500;
+  --color-viz-5: #d55181;
 }
 
 body {

--- a/src/lib/argent/TimeSeriesChart.svelte
+++ b/src/lib/argent/TimeSeriesChart.svelte
@@ -327,6 +327,8 @@ const tooltipLeftPct = $derived(
 	}
 
 	.axis {
+		/* No dedicated axis token exists; the stronger border step is the
+		   closest match. Promote to a --color-axis token if charts multiply. */
 		stroke: var(--color-border-hover);
 		stroke-width: 1;
 	}

--- a/src/lib/argent/TimeSeriesChart.svelte
+++ b/src/lib/argent/TimeSeriesChart.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 interface Series {
 	name: string;
-	// CSS custom property reference, e.g. 'var(--viz-1)'
+	// CSS custom property reference, e.g. 'var(--color-viz-1)'
 	color: string;
 	values: number[]; // cents, one per year
 }
@@ -254,8 +254,8 @@ const tooltipLeftPct = $derived(
 	.chart {
 		margin: 0;
 		padding: 1rem;
-		background: var(--card);
-		border: 1px solid var(--border);
+		background: var(--color-surface);
+		border: 1px solid var(--color-border);
 		border-radius: 0.5rem;
 	}
 
@@ -272,7 +272,7 @@ const tooltipLeftPct = $derived(
 
 	.value-label {
 		font-size: 0.8rem;
-		color: var(--muted);
+		color: var(--color-text-muted);
 	}
 
 	.legend {
@@ -280,7 +280,7 @@ const tooltipLeftPct = $derived(
 		gap: 1rem;
 		flex-wrap: wrap;
 		font-size: 0.8rem;
-		color: var(--ink-secondary);
+		color: var(--color-text-muted);
 		margin-bottom: 0.25rem;
 	}
 
@@ -300,7 +300,7 @@ const tooltipLeftPct = $derived(
 	.line-key {
 		width: 14px;
 		height: 0;
-		border-top: 2px solid var(--ink);
+		border-top: 2px solid var(--color-text);
 		display: inline-block;
 	}
 
@@ -317,46 +317,46 @@ const tooltipLeftPct = $derived(
 	}
 
 	svg:focus-visible {
-		outline: 2px solid var(--viz-1);
+		outline: 2px solid var(--color-accent);
 		outline-offset: 2px;
 	}
 
 	.grid {
-		stroke: var(--border);
+		stroke: var(--color-border);
 		stroke-width: 1;
 	}
 
 	.axis {
-		stroke: var(--axis);
+		stroke: var(--color-border-hover);
 		stroke-width: 1;
 	}
 
 	.tick,
 	.end-label {
 		font-size: 11px;
-		fill: var(--muted);
+		fill: var(--color-text-muted);
 		font-variant-numeric: tabular-nums;
 	}
 
 	.end-label {
-		fill: var(--ink-secondary);
+		fill: var(--color-text);
 		font-weight: 600;
 	}
 
 	.gap {
-		stroke: var(--card);
+		stroke: var(--color-surface);
 		stroke-width: 2;
 	}
 
 	.overlay {
-		stroke: var(--ink);
+		stroke: var(--color-text);
 		stroke-width: 2;
 		stroke-linejoin: round;
 		stroke-linecap: round;
 	}
 
 	.crosshair {
-		stroke: var(--muted);
+		stroke: var(--color-text-muted);
 		stroke-width: 1;
 	}
 
@@ -364,8 +364,8 @@ const tooltipLeftPct = $derived(
 		position: absolute;
 		top: 8px;
 		pointer-events: none;
-		background: var(--card);
-		border: 1px solid var(--border);
+		background: var(--color-bg);
+		border: 1px solid var(--color-border-hover);
 		border-radius: 0.4rem;
 		padding: 0.5rem 0.65rem;
 		font-size: 0.8rem;
@@ -375,7 +375,7 @@ const tooltipLeftPct = $derived(
 	}
 
 	.tooltip-head {
-		color: var(--muted);
+		color: var(--color-text-muted);
 		margin-bottom: 0.3rem;
 	}
 
@@ -399,6 +399,6 @@ const tooltipLeftPct = $derived(
 	}
 
 	.name {
-		color: var(--ink-secondary);
+		color: var(--color-text-muted);
 	}
 </style>

--- a/src/lib/argent/styles.ts
+++ b/src/lib/argent/styles.ts
@@ -1,0 +1,33 @@
+// Shared Tailwind class strings for the /retirement pages (ghost design
+// language — see DESIGN.md). Centralized so the four pages can't drift.
+//
+// Two input treatments: `input` is for controls sitting directly on the page;
+// `inputOnCard` is for controls inside a surface-colored card or table, where
+// it swaps to the page background so the field still reads as recessed.
+
+export const input =
+	'bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2.5 py-1.5 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
+
+export const inputOnCard =
+	'bg-[var(--color-bg)] border border-[var(--color-border)] rounded px-2 py-1 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
+
+export const btn =
+	'px-3 py-1.5 bg-[var(--color-accent)] text-white rounded text-sm font-medium hover:bg-[var(--color-accent-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors';
+
+// Label wrapper for a stacked field-name + control pair.
+export const field = 'flex flex-col gap-1 text-sm text-[var(--color-text-muted)]';
+
+export const th = 'text-left py-2 px-3 text-[var(--color-text-muted)] font-medium';
+export const td = 'py-2 px-3';
+
+// Dense variants for the wide year-by-year projection table.
+export const thDense =
+	'text-left py-1.5 px-2.5 text-[var(--color-text-muted)] font-medium whitespace-nowrap';
+export const tdDense = 'py-1.5 px-2.5 whitespace-nowrap';
+
+export const num = 'text-right tabular-nums';
+
+export const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
+
+export const banner =
+	'py-3 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] border-l-2 border-l-[var(--color-accent)] rounded-lg mb-4 text-sm flex flex-col gap-1';

--- a/src/routes/retirement/+layout.svelte
+++ b/src/routes/retirement/+layout.svelte
@@ -20,7 +20,14 @@
   <title>Ghost — Retirement</title>
 </svelte:head>
 
-<div class="argent">
+<div class="max-w-6xl mx-auto">
+  <div class="flex items-center justify-between mb-4">
+    <h1 class="text-2xl font-bold flex items-center gap-3">
+      <img src="/icon-retirement.svg" alt="" class="w-8 h-8" />
+      Retirement
+    </h1>
+  </div>
+
   <nav class="flex gap-1 mb-6">
     {#each tabs as tab}
       <a
@@ -36,42 +43,3 @@
 
   {@render children()}
 </div>
-
-<style>
-  /* Argent's pages and chart are styled against these tokens (see the
-     original argent +layout.svelte). Scoped to this section, remapped to
-     argent's dark palette so they sit inside ghost's dark theme. */
-  .argent {
-    --page: transparent;
-    --card: #1a1a19;
-    --ink: #ffffff;
-    --ink-secondary: #c3c2b7;
-    --muted: #898781;
-    --border: #2c2c2a;
-    --axis: #383835;
-    --error: #e66767;
-    --success: #0ca30c;
-    --viz-1: #3987e5;
-    --viz-2: #d95926;
-    --viz-3: #199e70;
-    --viz-4: #c98500;
-    --viz-5: #d55181;
-
-    max-width: 72rem;
-    margin: 0 auto;
-    color: var(--ink);
-  }
-
-  .argent :global(input),
-  .argent :global(select),
-  .argent :global(button) {
-    background: var(--card);
-    color: var(--ink);
-    border: 1px solid var(--axis);
-    border-radius: 0.3rem;
-  }
-
-  .argent :global(button) {
-    cursor: pointer;
-  }
-</style>

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -3,6 +3,14 @@ import { enhance } from '$app/forms';
 import TimeSeriesChart from '$lib/argent/TimeSeriesChart.svelte';
 import { project } from '$lib/argent/engine/project';
 import { formatCents } from '$lib/argent/format';
+import {
+	btn,
+	field,
+	inputOnCard,
+	num,
+	tdDense,
+	thDense,
+} from '$lib/argent/styles';
 import type { PageProps } from './$types';
 
 let { data, form }: PageProps = $props();
@@ -225,17 +233,6 @@ const fersAnnuityDisplay = $derived.by(() => {
 });
 
 const unit = $derived(showReal ? "today's dollars" : 'nominal dollars');
-
-// Shared Tailwind fragments (ghost design language — see DESIGN.md)
-const input =
-	'bg-[var(--color-bg)] border border-[var(--color-border)] rounded px-2 py-1 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
-const btn =
-	'px-3.5 py-1.5 bg-[var(--color-accent)] text-white rounded text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors';
-const knob = 'flex flex-col gap-1.5 text-sm text-[var(--color-text-muted)]';
-const th =
-	'text-left py-1.5 px-2.5 text-[var(--color-text-muted)] font-medium whitespace-nowrap';
-const td = 'py-1.5 px-2.5 whitespace-nowrap';
-const num = 'text-right tabular-nums';
 </script>
 
 <h2 class="text-xl font-semibold mb-3">Projection</h2>
@@ -247,27 +244,27 @@ const num = 'text-right tabular-nums';
 	class="py-3.5 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg mb-4"
 >
 	<div class="flex items-end gap-5 flex-wrap">
-		<label class="{knob} min-w-64">
+		<label class="{field} min-w-64">
 			<span>Retirement age <strong class="text-[var(--color-text)]">{retirementAge}</strong></span>
 			<input type="range" min="40" max="70" bind:value={retirementAge} class="accent-[var(--color-accent)]" />
 			<input type="hidden" name="retirementAge" value={retirementAge} />
 		</label>
-		<label class={knob}>
+		<label class={field}>
 			<span>SS claim age</span>
-			<input class="{input} w-20" type="number" min="62" max="70" bind:value={ssClaimingAge} />
+			<input class="{inputOnCard} w-20" type="number" min="62" max="70" bind:value={ssClaimingAge} />
 			<input type="hidden" name="ssClaimingAge" value={ssClaimingAge} />
 		</label>
-		<label class={knob}>
+		<label class={field}>
 			<span>Return %/yr</span>
-			<input class="{input} w-20" type="number" step="0.5" min="0" max="15" bind:value={returnPctInput} />
+			<input class="{inputOnCard} w-20" type="number" step="0.5" min="0" max="15" bind:value={returnPctInput} />
 			<input type="hidden" name="nominalReturnPct" value={returnPctInput / 100} />
 		</label>
-		<label class={knob}>
+		<label class={field}>
 			<span>Inflation %/yr</span>
-			<input class="{input} w-20" type="number" step="0.25" min="0" max="10" bind:value={inflationPctInput} />
+			<input class="{inputOnCard} w-20" type="number" step="0.25" min="0" max="10" bind:value={inflationPctInput} />
 			<input type="hidden" name="inflationPct" value={inflationPctInput / 100} />
 		</label>
-		<label class={knob}>
+		<label class={field}>
 			<span>Display</span>
 			<span class="flex items-center gap-1.5 py-1.5">
 				<input type="checkbox" bind:checked={showReal} class="accent-[var(--color-accent)]" />
@@ -283,20 +280,20 @@ const num = 'text-right tabular-nums';
 			More assumptions
 		</summary>
 		<div class="flex items-end gap-5 flex-wrap pt-2.5">
-			<label class={knob}>
+			<label class={field}>
 				<span>Birth date</span>
-				<input class={input} type="date" name="birthDate" bind:value={birthDate} />
+				<input class={inputOnCard} type="date" name="birthDate" bind:value={birthDate} />
 			</label>
-			<label class={knob}>
+			<label class={field}>
 				<span>State tax %</span>
-				<input class="{input} w-20" type="number" step="0.25" min="0" max="15" bind:value={stateTaxPctInput} />
+				<input class="{inputOnCard} w-20" type="number" step="0.25" min="0" max="15" bind:value={stateTaxPctInput} />
 				<input type="hidden" name="stateTaxPct" value={stateTaxPctInput / 100} />
 			</label>
-			<label class={knob}>
+			<label class={field}>
 				<span>End-of-plan age</span>
-				<input class="{input} w-20" type="number" name="endAge" min="70" max="110" bind:value={endAge} />
+				<input class="{inputOnCard} w-20" type="number" name="endAge" min="70" max="110" bind:value={endAge} />
 			</label>
-			<label class={knob}>
+			<label class={field}>
 				<span>Wage growth</span>
 				<span class="flex items-center gap-1.5 py-1.5">
 					<input type="checkbox" bind:checked={wageTracksInflation} class="accent-[var(--color-accent)]" />
@@ -304,9 +301,9 @@ const num = 'text-right tabular-nums';
 				</span>
 			</label>
 			{#if !wageTracksInflation}
-				<label class={knob}>
+				<label class={field}>
 					<span>Wage growth %/yr</span>
-					<input class="{input} w-20" type="number" step="0.25" min="0" max="10" bind:value={wageGrowthPctInput} />
+					<input class="{inputOnCard} w-20" type="number" step="0.25" min="0" max="10" bind:value={wageGrowthPctInput} />
 				</label>
 			{/if}
 			<input
@@ -386,17 +383,17 @@ const num = 'text-right tabular-nums';
 		<table class="w-full border-collapse text-sm">
 			<thead>
 				<tr class="border-b border-[var(--color-border)]">
-					<th class={th}>Year</th>
-					<th class={th}>Age</th>
-					<th class="{th} {num}">Salary</th>
-					<th class="{th} {num}">FERS</th>
-					<th class="{th} {num}">Soc. Sec.</th>
-					<th class="{th} {num}">Returns</th>
-					<th class="{th} {num}">Withdrawals</th>
-					<th class="{th} {num}">Taxes</th>
-					<th class="{th} {num}">Expenses</th>
-					<th class="{th} {num}">Net cash flow</th>
-					<th class="{th} {num}">Net worth</th>
+					<th class={thDense}>Year</th>
+					<th class={thDense}>Age</th>
+					<th class="{thDense} {num}">Salary</th>
+					<th class="{thDense} {num}">FERS</th>
+					<th class="{thDense} {num}">Soc. Sec.</th>
+					<th class="{thDense} {num}">Returns</th>
+					<th class="{thDense} {num}">Withdrawals</th>
+					<th class="{thDense} {num}">Taxes</th>
+					<th class="{thDense} {num}">Expenses</th>
+					<th class="{thDense} {num}">Net cash flow</th>
+					<th class="{thDense} {num}">Net worth</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -406,23 +403,23 @@ const num = 'text-right tabular-nums';
 							{r.shortfallCents > 0 ? 'text-[var(--color-error)]' : ''}
 							{r.age === retirementAge ? 'border-t-2 border-t-[var(--color-border-hover)]' : ''}"
 					>
-						<td class={td}>{r.year}</td>
-						<td class={td}>{r.age}</td>
-						<td class="{td} {num}">{r.salaryCents ? formatCents(display(r.salaryCents, i)) : '—'}</td>
-						<td class="{td} {num}">
+						<td class={tdDense}>{r.year}</td>
+						<td class={tdDense}>{r.age}</td>
+						<td class="{tdDense} {num}">{r.salaryCents ? formatCents(display(r.salaryCents, i)) : '—'}</td>
+						<td class="{tdDense} {num}">
 							{r.fersAnnuityCents + r.srsCents
 								? formatCents(display(r.fersAnnuityCents + r.srsCents, i))
 								: '—'}
 						</td>
-						<td class="{td} {num}">
+						<td class="{tdDense} {num}">
 							{r.ssBenefitCents ? formatCents(display(r.ssBenefitCents, i)) : '—'}
 						</td>
-						<td class="{td} {num}">
+						<td class="{tdDense} {num}">
 							{r.investmentGrowthCents
 								? formatCents(display(r.investmentGrowthCents, i))
 								: '—'}
 						</td>
-						<td class="{td} {num}">
+						<td class="{tdDense} {num}">
 							{formatCents(
 								display(
 									r.withdrawalCashCents +
@@ -434,7 +431,7 @@ const num = 'text-right tabular-nums';
 								),
 							)}
 						</td>
-						<td class="{td} {num}">
+						<td class="{tdDense} {num}">
 							{formatCents(
 								display(
 									r.federalTaxCents +
@@ -446,9 +443,9 @@ const num = 'text-right tabular-nums';
 								),
 							)}
 						</td>
-						<td class="{td} {num}">{formatCents(display(r.expensesCents, i))}</td>
-						<td class="{td} {num}">{formatCents(display(r.netCashFlowCents, i))}</td>
-						<td class="{td} {num}">{formatCents(display(r.netWorthCents, i))}</td>
+						<td class="{tdDense} {num}">{formatCents(display(r.expensesCents, i))}</td>
+						<td class="{tdDense} {num}">{formatCents(display(r.netCashFlowCents, i))}</td>
+						<td class="{tdDense} {num}">{formatCents(display(r.netWorthCents, i))}</td>
 					</tr>
 				{/each}
 			</tbody>

--- a/src/routes/retirement/+page.svelte
+++ b/src/routes/retirement/+page.svelte
@@ -57,22 +57,22 @@ const display = $derived((cents: number, i: number) =>
 const wealthStacks = $derived([
 	{
 		name: 'Cash',
-		color: 'var(--viz-4)',
+		color: 'var(--color-viz-4)',
 		values: rows.map((r, i) => display(r.cashCents, i)),
 	},
 	{
 		name: 'Taxable',
-		color: 'var(--viz-1)',
+		color: 'var(--color-viz-1)',
 		values: rows.map((r, i) => display(r.taxableCents, i)),
 	},
 	{
 		name: 'Tax-deferred',
-		color: 'var(--viz-2)',
+		color: 'var(--color-viz-2)',
 		values: rows.map((r, i) => display(r.deferredCents, i)),
 	},
 	{
 		name: 'Roth',
-		color: 'var(--viz-3)',
+		color: 'var(--color-viz-3)',
 		values: rows.map((r, i) => display(r.rothCents, i)),
 	},
 ]);
@@ -80,27 +80,27 @@ const wealthStacks = $derived([
 const incomeStacks = $derived([
 	{
 		name: 'Salary',
-		color: 'var(--viz-1)',
+		color: 'var(--color-viz-1)',
 		values: rows.map((r, i) => display(r.salaryCents, i)),
 	},
 	{
 		name: 'FERS annuity',
-		color: 'var(--viz-2)',
+		color: 'var(--color-viz-2)',
 		values: rows.map((r, i) => display(r.fersAnnuityCents + r.srsCents, i)),
 	},
 	{
 		name: 'Social Security',
-		color: 'var(--viz-3)',
+		color: 'var(--color-viz-3)',
 		values: rows.map((r, i) => display(r.ssBenefitCents, i)),
 	},
 	{
 		name: 'Investment returns',
-		color: 'var(--viz-4)',
+		color: 'var(--color-viz-4)',
 		values: rows.map((r, i) => display(r.investmentGrowthCents, i)),
 	},
 	{
 		name: 'Employer benefits (in-kind)',
-		color: 'var(--viz-5)',
+		color: 'var(--color-viz-5)',
 		values: rows.map((r, i) =>
 			display(r.healthInKindCents + r.employerTspCents, i),
 		),
@@ -142,10 +142,10 @@ const expenseCategoryOrder = $derived.by(() => {
 
 const expenseStacks = $derived.by(() => {
 	const vizColors = [
-		'var(--viz-1)',
-		'var(--viz-2)',
-		'var(--viz-3)',
-		'var(--viz-4)',
+		'var(--color-viz-1)',
+		'var(--color-viz-2)',
+		'var(--color-viz-3)',
+		'var(--color-viz-4)',
 	];
 	const top = expenseCategoryOrder.slice(0, 4);
 	const rest = expenseCategoryOrder.slice(4);
@@ -157,7 +157,7 @@ const expenseStacks = $derived.by(() => {
 	if (rest.length > 0) {
 		stacks.push({
 			name: 'Everything else',
-			color: 'var(--viz-5)',
+			color: 'var(--color-viz-5)',
 			values: rows.map((r, i) =>
 				display(
 					rest.reduce((s, n) => s + (r.expensesByCategory[n] ?? 0), 0),
@@ -172,27 +172,27 @@ const expenseStacks = $derived.by(() => {
 const taxStacks = $derived([
 	{
 		name: 'Federal income',
-		color: 'var(--viz-1)',
+		color: 'var(--color-viz-1)',
 		values: rows.map((r, i) => display(r.federalTaxCents, i)),
 	},
 	{
 		name: 'FICA',
-		color: 'var(--viz-2)',
+		color: 'var(--color-viz-2)',
 		values: rows.map((r, i) => display(r.ficaCents, i)),
 	},
 	{
 		name: 'State',
-		color: 'var(--viz-3)',
+		color: 'var(--color-viz-3)',
 		values: rows.map((r, i) => display(r.stateTaxCents, i)),
 	},
 	{
 		name: 'Capital gains',
-		color: 'var(--viz-4)',
+		color: 'var(--color-viz-4)',
 		values: rows.map((r, i) => display(r.capitalGainsTaxCents, i)),
 	},
 	{
 		name: 'Early-withdrawal penalty',
-		color: 'var(--viz-5)',
+		color: 'var(--color-viz-5)',
 		values: rows.map((r, i) => display(r.earlyWithdrawalPenaltyCents, i)),
 	},
 ]);
@@ -225,70 +225,88 @@ const fersAnnuityDisplay = $derived.by(() => {
 });
 
 const unit = $derived(showReal ? "today's dollars" : 'nominal dollars');
+
+// Shared Tailwind fragments (ghost design language — see DESIGN.md)
+const input =
+	'bg-[var(--color-bg)] border border-[var(--color-border)] rounded px-2 py-1 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
+const btn =
+	'px-3.5 py-1.5 bg-[var(--color-accent)] text-white rounded text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors';
+const knob = 'flex flex-col gap-1.5 text-sm text-[var(--color-text-muted)]';
+const th =
+	'text-left py-1.5 px-2.5 text-[var(--color-text-muted)] font-medium whitespace-nowrap';
+const td = 'py-1.5 px-2.5 whitespace-nowrap';
+const num = 'text-right tabular-nums';
 </script>
 
-<h1>Projection</h1>
+<h2 class="text-xl font-semibold mb-3">Projection</h2>
 
-<form method="POST" action="?/save" use:enhance class="knobs">
-	<div class="knob-row">
-		<label class="knob wide">
-			<span>Retirement age <strong>{retirementAge}</strong></span>
-			<input type="range" min="40" max="70" bind:value={retirementAge} />
+<form
+	method="POST"
+	action="?/save"
+	use:enhance
+	class="py-3.5 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg mb-4"
+>
+	<div class="flex items-end gap-5 flex-wrap">
+		<label class="{knob} min-w-64">
+			<span>Retirement age <strong class="text-[var(--color-text)]">{retirementAge}</strong></span>
+			<input type="range" min="40" max="70" bind:value={retirementAge} class="accent-[var(--color-accent)]" />
 			<input type="hidden" name="retirementAge" value={retirementAge} />
 		</label>
-		<label class="knob">
+		<label class={knob}>
 			<span>SS claim age</span>
-			<input type="number" min="62" max="70" bind:value={ssClaimingAge} />
+			<input class="{input} w-20" type="number" min="62" max="70" bind:value={ssClaimingAge} />
 			<input type="hidden" name="ssClaimingAge" value={ssClaimingAge} />
 		</label>
-		<label class="knob">
+		<label class={knob}>
 			<span>Return %/yr</span>
-			<input type="number" step="0.5" min="0" max="15" bind:value={returnPctInput} />
+			<input class="{input} w-20" type="number" step="0.5" min="0" max="15" bind:value={returnPctInput} />
 			<input type="hidden" name="nominalReturnPct" value={returnPctInput / 100} />
 		</label>
-		<label class="knob">
+		<label class={knob}>
 			<span>Inflation %/yr</span>
-			<input type="number" step="0.25" min="0" max="10" bind:value={inflationPctInput} />
+			<input class="{input} w-20" type="number" step="0.25" min="0" max="10" bind:value={inflationPctInput} />
 			<input type="hidden" name="inflationPct" value={inflationPctInput / 100} />
 		</label>
-		<label class="knob toggle">
+		<label class={knob}>
 			<span>Display</span>
-			<span class="toggle-row">
-				<input type="checkbox" bind:checked={showReal} />
+			<span class="flex items-center gap-1.5 py-1.5">
+				<input type="checkbox" bind:checked={showReal} class="accent-[var(--color-accent)]" />
 				today's $
 			</span>
 		</label>
-		<button type="submit">Save as defaults</button>
-		{#if form?.error}<span class="error">{form.error}</span>{/if}
+		<button type="submit" class={btn}>Save as defaults</button>
+		{#if form?.error}<span class="text-sm text-[var(--color-error)]">{form.error}</span>{/if}
 	</div>
 
-	<details class="more">
-		<summary>More assumptions</summary>
-		<div class="knob-row">
-			<label class="knob">
+	<details class="mt-2.5">
+		<summary class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)] py-1 select-none">
+			More assumptions
+		</summary>
+		<div class="flex items-end gap-5 flex-wrap pt-2.5">
+			<label class={knob}>
 				<span>Birth date</span>
-				<input type="date" name="birthDate" bind:value={birthDate} />
+				<input class={input} type="date" name="birthDate" bind:value={birthDate} />
 			</label>
-			<label class="knob">
+			<label class={knob}>
 				<span>State tax %</span>
-				<input type="number" step="0.25" min="0" max="15" bind:value={stateTaxPctInput} />
+				<input class="{input} w-20" type="number" step="0.25" min="0" max="15" bind:value={stateTaxPctInput} />
 				<input type="hidden" name="stateTaxPct" value={stateTaxPctInput / 100} />
 			</label>
-			<label class="knob">
+			<label class={knob}>
 				<span>End-of-plan age</span>
-				<input type="number" name="endAge" min="70" max="110" bind:value={endAge} />
+				<input class="{input} w-20" type="number" name="endAge" min="70" max="110" bind:value={endAge} />
 			</label>
-			<label class="knob toggle">
+			<label class={knob}>
 				<span>Wage growth</span>
-				<span class="toggle-row">
-					<input type="checkbox" bind:checked={wageTracksInflation} />
+				<span class="flex items-center gap-1.5 py-1.5">
+					<input type="checkbox" bind:checked={wageTracksInflation} class="accent-[var(--color-accent)]" />
 					track inflation
 				</span>
 			</label>
 			{#if !wageTracksInflation}
-				<label class="knob">
+				<label class={knob}>
 					<span>Wage growth %/yr</span>
-					<input type="number" step="0.25" min="0" max="10" bind:value={wageGrowthPctInput} />
+					<input class="{input} w-20" type="number" step="0.25" min="0" max="10" bind:value={wageGrowthPctInput} />
 				</label>
 			{/if}
 			<input
@@ -300,35 +318,35 @@ const unit = $derived(showReal ? "today's dollars" : 'nominal dollars');
 	</details>
 </form>
 
-<section class="tiles">
-	<div class="tile">
-		<span class="label">Plan status</span>
+<section class="grid grid-cols-[repeat(auto-fit,minmax(12rem,1fr))] gap-4 mb-4">
+	<div class="flex flex-col gap-1 py-3.5 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg">
+		<span class="text-xs text-[var(--color-text-muted)]">Plan status</span>
 		{#if projection.firstShortfallAge === null}
-			<span class="value ok">Funded to {endAge}</span>
+			<span class="text-xl font-semibold text-[var(--color-success)]">Funded to {endAge}</span>
 		{:else}
-			<span class="value bad">⚠ Shortfall at {projection.firstShortfallAge}</span>
+			<span class="text-xl font-semibold text-[var(--color-error)]">⚠ Shortfall at {projection.firstShortfallAge}</span>
 		{/if}
 	</div>
-	<div class="tile">
-		<span class="label">Net worth at {retirementAge}</span>
-		<span class="value">{formatCents(netWorthAtRetirement)}</span>
+	<div class="flex flex-col gap-1 py-3.5 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg">
+		<span class="text-xs text-[var(--color-text-muted)]">Net worth at {retirementAge}</span>
+		<span class="text-xl font-semibold">{formatCents(netWorthAtRetirement)}</span>
 	</div>
-	<div class="tile">
-		<span class="label">
+	<div class="flex flex-col gap-1 py-3.5 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg">
+		<span class="text-xs text-[var(--color-text-muted)]">
 			FERS annuity from {fersAnnuityDisplay?.age ?? '—'}
 			{#if fersAnnuityDisplay?.deferred}(deferred){/if}
 		</span>
-		<span class="value">
+		<span class="text-xl font-semibold">
 			{fersAnnuityDisplay ? `${formatCents(fersAnnuityDisplay.annual)}/yr` : 'not eligible'}
 		</span>
 	</div>
-	<div class="tile">
-		<span class="label">Social Security at {ssClaimingAge}</span>
-		<span class="value">{formatCents(projection.ssMonthlyAtClaimTodayCents)}/mo</span>
+	<div class="flex flex-col gap-1 py-3.5 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg">
+		<span class="text-xs text-[var(--color-text-muted)]">Social Security at {ssClaimingAge}</span>
+		<span class="text-xl font-semibold">{formatCents(projection.ssMonthlyAtClaimTodayCents)}/mo</span>
 	</div>
 </section>
 
-<div class="charts">
+<div class="flex flex-col gap-4 mb-4">
 	<TimeSeriesChart
 		title="Wealth by bucket"
 		valueLabel={unit}
@@ -360,45 +378,51 @@ const unit = $derived(showReal ? "today's dollars" : 'nominal dollars');
 	/>
 </div>
 
-<details>
-	<summary>Year-by-year table</summary>
-	<div class="table-wrap">
-		<table>
+<details class="mb-4">
+	<summary class="text-[var(--color-text-muted)] hover:text-[var(--color-text)] py-2 select-none">
+		Year-by-year table
+	</summary>
+	<div class="overflow-x-auto bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg">
+		<table class="w-full border-collapse text-sm">
 			<thead>
-				<tr>
-					<th>Year</th>
-					<th>Age</th>
-					<th class="num">Salary</th>
-					<th class="num">FERS</th>
-					<th class="num">Soc. Sec.</th>
-					<th class="num">Returns</th>
-					<th class="num">Withdrawals</th>
-					<th class="num">Taxes</th>
-					<th class="num">Expenses</th>
-					<th class="num">Net cash flow</th>
-					<th class="num">Net worth</th>
+				<tr class="border-b border-[var(--color-border)]">
+					<th class={th}>Year</th>
+					<th class={th}>Age</th>
+					<th class="{th} {num}">Salary</th>
+					<th class="{th} {num}">FERS</th>
+					<th class="{th} {num}">Soc. Sec.</th>
+					<th class="{th} {num}">Returns</th>
+					<th class="{th} {num}">Withdrawals</th>
+					<th class="{th} {num}">Taxes</th>
+					<th class="{th} {num}">Expenses</th>
+					<th class="{th} {num}">Net cash flow</th>
+					<th class="{th} {num}">Net worth</th>
 				</tr>
 			</thead>
 			<tbody>
 				{#each rows as r, i (r.year)}
-					<tr class:shortfall={r.shortfallCents > 0} class:separation={r.age === retirementAge}>
-						<td>{r.year}</td>
-						<td>{r.age}</td>
-						<td class="num">{r.salaryCents ? formatCents(display(r.salaryCents, i)) : '—'}</td>
-						<td class="num">
+					<tr
+						class="border-b border-[var(--color-border)] last:border-b-0
+							{r.shortfallCents > 0 ? 'text-[var(--color-error)]' : ''}
+							{r.age === retirementAge ? 'border-t-2 border-t-[var(--color-border-hover)]' : ''}"
+					>
+						<td class={td}>{r.year}</td>
+						<td class={td}>{r.age}</td>
+						<td class="{td} {num}">{r.salaryCents ? formatCents(display(r.salaryCents, i)) : '—'}</td>
+						<td class="{td} {num}">
 							{r.fersAnnuityCents + r.srsCents
 								? formatCents(display(r.fersAnnuityCents + r.srsCents, i))
 								: '—'}
 						</td>
-						<td class="num">
+						<td class="{td} {num}">
 							{r.ssBenefitCents ? formatCents(display(r.ssBenefitCents, i)) : '—'}
 						</td>
-						<td class="num">
+						<td class="{td} {num}">
 							{r.investmentGrowthCents
 								? formatCents(display(r.investmentGrowthCents, i))
 								: '—'}
 						</td>
-						<td class="num">
+						<td class="{td} {num}">
 							{formatCents(
 								display(
 									r.withdrawalCashCents +
@@ -410,7 +434,7 @@ const unit = $derived(showReal ? "today's dollars" : 'nominal dollars');
 								),
 							)}
 						</td>
-						<td class="num">
+						<td class="{td} {num}">
 							{formatCents(
 								display(
 									r.federalTaxCents +
@@ -422,9 +446,9 @@ const unit = $derived(showReal ? "today's dollars" : 'nominal dollars');
 								),
 							)}
 						</td>
-						<td class="num">{formatCents(display(r.expensesCents, i))}</td>
-						<td class="num">{formatCents(display(r.netCashFlowCents, i))}</td>
-						<td class="num">{formatCents(display(r.netWorthCents, i))}</td>
+						<td class="{td} {num}">{formatCents(display(r.expensesCents, i))}</td>
+						<td class="{td} {num}">{formatCents(display(r.netCashFlowCents, i))}</td>
+						<td class="{td} {num}">{formatCents(display(r.netWorthCents, i))}</td>
 					</tr>
 				{/each}
 			</tbody>
@@ -432,9 +456,9 @@ const unit = $derived(showReal ? "today's dollars" : 'nominal dollars');
 	</div>
 </details>
 
-<p class="footnote">
+<p class="text-xs text-[var(--color-text-muted)] max-w-3xl">
 	All amounts in {unit}. Constants (tax brackets, bend points, limits) are 2026
-	figures — see <code>src/lib/engine/constants.ts</code>.
+	figures — see <code>src/lib/argent/engine/constants.ts</code>.
 	{#if projection.fers.eligible && !projection.fers.immediate}
 		Retiring at {retirementAge} is before FERS immediate eligibility: the annuity
 		defers to 62 with the high-3 frozen at separation, and there is no retiree
@@ -442,161 +466,3 @@ const unit = $derived(showReal ? "today's dollars" : 'nominal dollars');
 		insurance.
 	{/if}
 </p>
-
-<style>
-	.knobs {
-		padding: 0.9rem 1rem;
-		background: var(--card);
-		border: 1px solid var(--border);
-		border-radius: 0.5rem;
-		margin-bottom: 1rem;
-	}
-
-	.knob-row {
-		display: flex;
-		align-items: end;
-		gap: 1.25rem;
-		flex-wrap: wrap;
-	}
-
-	.more {
-		margin-top: 0.6rem;
-	}
-
-	.more summary {
-		cursor: pointer;
-		font-size: 0.85rem;
-		color: var(--ink-secondary);
-		padding: 0.2rem 0;
-	}
-
-	.more .knob-row {
-		padding-top: 0.6rem;
-	}
-
-	.knob {
-		display: flex;
-		flex-direction: column;
-		gap: 0.3rem;
-		font-size: 0.85rem;
-		color: var(--ink-secondary);
-	}
-
-	.knob.wide {
-		min-width: 16rem;
-	}
-
-	.knob input[type='number'] {
-		width: 5rem;
-		padding: 0.3rem 0.45rem;
-		font-size: 0.95rem;
-	}
-
-	.toggle-row {
-		display: flex;
-		align-items: center;
-		gap: 0.4rem;
-		padding: 0.35rem 0;
-	}
-
-	.knobs button {
-		padding: 0.45rem 0.9rem;
-		font-size: 0.9rem;
-	}
-
-	.tiles {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
-		gap: 1rem;
-		margin-bottom: 1rem;
-	}
-
-	.tile {
-		display: flex;
-		flex-direction: column;
-		gap: 0.3rem;
-		padding: 0.9rem 1rem;
-		background: var(--card);
-		border: 1px solid var(--border);
-		border-radius: 0.5rem;
-	}
-
-	.tile .label {
-		font-size: 0.8rem;
-		color: var(--ink-secondary);
-	}
-
-	.tile .value {
-		font-size: 1.35rem;
-		font-weight: 600;
-	}
-
-	.tile .value.ok {
-		color: var(--success);
-	}
-
-	.tile .value.bad {
-		color: var(--error);
-	}
-
-	.charts {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-		margin-bottom: 1rem;
-	}
-
-	details {
-		margin-bottom: 1rem;
-	}
-
-	summary {
-		cursor: pointer;
-		color: var(--ink-secondary);
-		padding: 0.5rem 0;
-	}
-
-	.table-wrap {
-		overflow-x: auto;
-		background: var(--card);
-		border: 1px solid var(--border);
-		border-radius: 0.5rem;
-	}
-
-	table {
-		border-collapse: collapse;
-		width: 100%;
-		font-size: 0.85rem;
-	}
-
-	th,
-	td {
-		text-align: left;
-		padding: 0.3rem 0.6rem;
-		border-bottom: 1px solid var(--border);
-		white-space: nowrap;
-	}
-
-	.num {
-		text-align: right;
-		font-variant-numeric: tabular-nums;
-	}
-
-	tr.shortfall td {
-		color: var(--error);
-	}
-
-	tr.separation td {
-		border-top: 2px solid var(--axis);
-	}
-
-	.footnote {
-		font-size: 0.8rem;
-		color: var(--muted);
-		max-width: 46rem;
-	}
-
-	.error {
-		color: var(--error);
-	}
-</style>

--- a/src/routes/retirement/accounts/+page.svelte
+++ b/src/routes/retirement/accounts/+page.svelte
@@ -66,11 +66,25 @@ const missingBasis = $derived(
 		(r) => rowIsRoth(r) && parseDollarsToCents(r.rothBasis) == null,
 	),
 );
+
+// Shared Tailwind fragments (ghost design language — see DESIGN.md)
+const input =
+	'bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2.5 py-1.5 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
+const cellInput =
+	'bg-[var(--color-bg)] border border-[var(--color-border)] rounded px-2 py-1 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
+const btn =
+	'px-3 py-1.5 bg-[var(--color-accent)] text-white rounded text-sm font-medium hover:bg-[var(--color-accent-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors';
+const label = 'flex flex-col gap-1 text-sm text-[var(--color-text-muted)]';
+const th = 'text-left py-2 px-3 text-[var(--color-text-muted)] font-medium';
+const td = 'py-2 px-3';
+const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
+const banner =
+	'py-3 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] border-l-2 border-l-[var(--color-accent)] rounded-lg mb-4 text-sm flex flex-col gap-1';
 </script>
 
-<h1>Accounts</h1>
+<h2 class="text-xl font-semibold mb-2">Accounts</h2>
 
-<p class="hint">
+<p class="text-sm text-[var(--color-text-muted)] max-w-2xl mb-4">
 	Current balances. The engine folds these into three buckets: taxable,
 	tax-deferred, and Roth. Basis matters for taxes: Roth basis is
 	withdrawable any time; taxable cost basis (from your brokerage's
@@ -78,18 +92,19 @@ const missingBasis = $derived(
 	blank means "no embedded gains," which understates future tax.
 </p>
 
-<section class="buckets">
-	<div><span class="label">Cash</span><span>{formatCents(data.buckets.cashCents)}</span></div>
-	<div><span class="label">Taxable</span><span>{formatCents(data.buckets.taxableCents)}</span></div>
-	<div>
-		<span class="label">Tax-deferred</span><span>{formatCents(data.buckets.deferredCents)}</span>
-	</div>
-	<div>
-		<span class="label">Roth</span><span>{formatCents(data.buckets.rothCents)}</span>
-	</div>
-	<div>
-		<span class="label">Roth basis</span><span>{formatCents(data.buckets.rothBasisCents)}</span>
-	</div>
+<section class="flex gap-4 mb-6 flex-wrap">
+	{#each [
+		{ name: 'Cash', cents: data.buckets.cashCents },
+		{ name: 'Taxable', cents: data.buckets.taxableCents },
+		{ name: 'Tax-deferred', cents: data.buckets.deferredCents },
+		{ name: 'Roth', cents: data.buckets.rothCents },
+		{ name: 'Roth basis', cents: data.buckets.rothBasisCents },
+	] as { name, cents } (name)}
+		<div class="flex flex-col gap-0.5 py-3 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg font-semibold">
+			<span class="text-xs font-normal text-[var(--color-text-muted)]">{name}</span>
+			<span>{formatCents(cents)}</span>
+		</div>
+	{/each}
 </section>
 
 <form
@@ -97,73 +112,75 @@ const missingBasis = $derived(
 	action="?/importBalances"
 	enctype="multipart/form-data"
 	use:enhance
-	class="import-row"
+	class="flex items-end gap-4 mb-4 flex-wrap"
 >
-	<label class="file-label">
+	<label class={label}>
 		Import balances CSV (Date,Balance,Account)
-		<input name="balances" type="file" accept=".csv,text/csv" required />
+		<input class={input} name="balances" type="file" accept=".csv,text/csv" required />
 	</label>
-	<button type="submit">Parse CSV</button>
+	<button type="submit" class={btn}>Parse CSV</button>
 </form>
 
 {#if imported != null}
-	<div class="banner">
+	<div class="{banner} max-w-2xl">
 		<strong>Imported {imported} account{imported === 1 ? '' : 's'}.</strong>
 	</div>
 {/if}
 
 {#if parsed && importRows.length > 0}
-	<div class="banner">
+	<div class="{banner} max-w-3xl">
 		<strong>Found {parsed.accounts.length} accounts</strong>
 		{#if parsed.asOfDate}(balances as of {parsed.asOfDate}){/if}
 		— uncheck anything that shouldn't be modeled (a spouse's account, a
 		sinking fund…), fix kinds, add Roth basis where asked, then import.
 		{#if importRows.some((r) => r.kind === 'tsp-traditional' && /thrift|tsp/i.test(r.name))}
-			<span class="note">
+			<span class="text-[var(--color-text-muted)]">
 				The CSV shows one combined TSP balance — it can't see your
 				traditional/Roth split. Import it, then split it into two rows
 				(TSP traditional / TSP Roth) using your TSP statement.
 			</span>
 		{/if}
 		{#if parsed.skipped.length > 0}
-			<span class="note">
+			<span class="text-[var(--color-text-muted)]">
 				Skipped (zero or negative): {parsed.skipped.map((s) => s.name).join(', ')}
 			</span>
 		{/if}
 		{#each parsed.warnings as w (w)}
-			<span class="warning">⚠ {w}</span>
+			<span class="text-[var(--color-error)]">⚠ {w}</span>
 		{/each}
 	</div>
 
-	<div class="table-wrap">
-		<table>
+	<div class="overflow-x-auto bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg mb-3">
+		<table class="w-full border-collapse text-sm">
 			<thead>
-				<tr>
-					<th></th>
-					<th>Name</th>
-					<th>Kind</th>
-					<th class="num">Balance</th>
-					<th class="num">Roth basis ($)</th>
-					<th>Last update</th>
+				<tr class="border-b border-[var(--color-border)]">
+					<th class={th}></th>
+					<th class={th}>Name</th>
+					<th class={th}>Kind</th>
+					<th class="{th} text-right">Balance</th>
+					<th class="{th} text-right">Roth basis ($)</th>
+					<th class={th}>Last update</th>
 				</tr>
 			</thead>
 			<tbody>
 				{#each importRows as row, i (i)}
-					<tr class:excluded={!row.include}>
-						<td><input type="checkbox" bind:checked={row.include} /></td>
-						<td><input class="name-input" bind:value={row.name} disabled={!row.include} /></td>
-						<td>
-							<select bind:value={row.kind} disabled={!row.include}>
+					<tr class="{bodyRow} {row.include ? '' : 'opacity-45'}">
+						<td class={td}><input type="checkbox" class="accent-[var(--color-accent)]" bind:checked={row.include} /></td>
+						<td class={td}>
+							<input class="{cellInput} w-full min-w-56" bind:value={row.name} disabled={!row.include} />
+						</td>
+						<td class={td}>
+							<select class={cellInput} bind:value={row.kind} disabled={!row.include}>
 								{#each data.accountKinds as k (k)}
 									<option value={k}>{KIND_LABELS[k]}</option>
 								{/each}
 							</select>
 						</td>
-						<td class="num">{formatCents(row.balanceCents)}</td>
-						<td class="num">
+						<td class="{td} text-right tabular-nums">{formatCents(row.balanceCents)}</td>
+						<td class="{td} text-right">
 							{#if rowIsRoth(row)}
 								<input
-									class="basis-input"
+									class="{cellInput} w-30 text-right"
 									bind:value={row.rothBasis}
 									placeholder="required"
 									disabled={!row.include}
@@ -172,284 +189,118 @@ const missingBasis = $derived(
 								—
 							{/if}
 						</td>
-						<td>{row.lastDate}</td>
+						<td class={td}>{row.lastDate}</td>
 					</tr>
 				{/each}
 			</tbody>
 		</table>
 	</div>
 
-	<form method="POST" action="?/importSave" use:enhance class="import-actions">
+	<form method="POST" action="?/importSave" use:enhance class="flex items-center gap-4 mb-6">
 		<input type="hidden" name="rows" value={importPayload} />
-		<button type="submit" disabled={selectedRows.length === 0 || missingBasis}>
+		<button type="submit" class={btn} disabled={selectedRows.length === 0 || missingBasis}>
 			Import {selectedRows.length} selected
 		</button>
 		{#if missingBasis}
-			<span class="warning">Enter a contribution basis for the selected Roth accounts.</span>
+			<span class="text-sm text-[var(--color-error)]">Enter a contribution basis for the selected Roth accounts.</span>
 		{/if}
 	</form>
 {/if}
 
-{#if form?.error}<p class="error">{form.error}</p>{/if}
+{#if form?.error}<p class="text-sm text-[var(--color-error)] mb-4">{form.error}</p>{/if}
 
 {#if data.accounts.length > 0}
-	<table>
-		<thead>
-			<tr>
-				<th>Name</th>
-				<th>Kind</th>
-				<th class="num">Balance</th>
-				<th class="num">Basis</th>
-				<th></th>
-			</tr>
-		</thead>
-		<tbody>
-			{#each data.accounts as account (account.id)}
-				<tr>
-					<td>{account.name}</td>
-					<td>{KIND_LABELS[account.kind] ?? account.kind}</td>
-					<td class="num">
-						<input
-							class="cell-input"
-							name="balance"
-							form="acct-{account.id}"
-							value={dollars(account.balanceCents)}
-							required
-						/>
-					</td>
-					<td class="num">
-						{#if account.kind === 'tsp-roth' || account.kind === 'ira-roth'}
+	<div class="overflow-x-auto bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg mb-6">
+		<table class="w-full border-collapse text-sm">
+			<thead>
+				<tr class="border-b border-[var(--color-border)]">
+					<th class={th}>Name</th>
+					<th class={th}>Kind</th>
+					<th class="{th} text-right">Balance</th>
+					<th class="{th} text-right">Basis</th>
+					<th class={th}></th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each data.accounts as account (account.id)}
+					<tr class={bodyRow}>
+						<td class={td}>{account.name}</td>
+						<td class={td}>{KIND_LABELS[account.kind] ?? account.kind}</td>
+						<td class="{td} text-right">
 							<input
-								class="cell-input"
-								name="rothBasis"
+								class="{cellInput} w-32 text-right"
+								name="balance"
 								form="acct-{account.id}"
-								value={dollars(account.rothBasisCents ?? 0)}
+								value={dollars(account.balanceCents)}
 								required
 							/>
-						{:else if account.kind === 'taxable'}
-							<input
-								class="cell-input"
-								name="costBasis"
-								form="acct-{account.id}"
-								value={account.costBasisCents != null ? dollars(account.costBasisCents) : ''}
-								placeholder="= balance"
-							/>
-						{:else}
-							—
-						{/if}
-					</td>
-					<td class="row-actions">
-						<form id="acct-{account.id}" method="POST" action="?/update" use:enhance>
-							<input type="hidden" name="id" value={account.id} />
-							<button type="submit" class="link save">save</button>
-						</form>
-						<form method="POST" action="?/delete" use:enhance>
-							<input type="hidden" name="id" value={account.id} />
-							<button type="submit" class="link">delete</button>
-						</form>
-					</td>
-				</tr>
-			{/each}
-		</tbody>
-	</table>
+						</td>
+						<td class="{td} text-right">
+							{#if account.kind === 'tsp-roth' || account.kind === 'ira-roth'}
+								<input
+									class="{cellInput} w-32 text-right"
+									name="rothBasis"
+									form="acct-{account.id}"
+									value={dollars(account.rothBasisCents ?? 0)}
+									required
+								/>
+							{:else if account.kind === 'taxable'}
+								<input
+									class="{cellInput} w-32 text-right"
+									name="costBasis"
+									form="acct-{account.id}"
+									value={account.costBasisCents != null ? dollars(account.costBasisCents) : ''}
+									placeholder="= balance"
+								/>
+							{:else}
+								—
+							{/if}
+						</td>
+						<td class={td}>
+							<div class="flex gap-3 items-center">
+								<form id="acct-{account.id}" method="POST" action="?/update" use:enhance>
+									<input type="hidden" name="id" value={account.id} />
+									<button type="submit" class="text-xs text-[var(--color-success)] hover:underline">save</button>
+								</form>
+								<form method="POST" action="?/delete" use:enhance>
+									<input type="hidden" name="id" value={account.id} />
+									<button type="submit" class="text-xs text-[var(--color-error)] hover:underline">delete</button>
+								</form>
+							</div>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
 {:else}
-	<p>No accounts yet.</p>
+	<p class="text-[var(--color-text-muted)] mb-6">No accounts yet.</p>
 {/if}
 
-<h2>Add account</h2>
+<h3 class="text-lg font-semibold mb-3">Add account</h3>
 
-<form method="POST" action="?/create" use:enhance class="inline">
-	<label>
+<form method="POST" action="?/create" use:enhance class="flex items-end gap-4 flex-wrap">
+	<label class={label}>
 		Name
-		<input name="name" required />
+		<input class={input} name="name" required />
 	</label>
-	<label>
+	<label class={label}>
 		Kind
-		<select name="kind" bind:value={kind}>
+		<select class={input} name="kind" bind:value={kind}>
 			{#each data.accountKinds as k (k)}
 				<option value={k}>{KIND_LABELS[k]}</option>
 			{/each}
 		</select>
 	</label>
-	<label>
+	<label class={label}>
 		Balance ($)
-		<input name="balance" required />
+		<input class={input} name="balance" required />
 	</label>
 	{#if isRoth}
-		<label>
+		<label class={label}>
 			Contribution basis ($)
-			<input name="rothBasis" required />
+			<input class={input} name="rothBasis" required />
 		</label>
 	{/if}
-	<button type="submit">Add</button>
+	<button type="submit" class={btn}>Add</button>
 </form>
-
-<style>
-	.hint {
-		color: var(--ink-secondary);
-		max-width: 40rem;
-	}
-
-	.buckets {
-		display: flex;
-		gap: 1rem;
-		margin-bottom: 1.5rem;
-		flex-wrap: wrap;
-	}
-
-	.buckets div {
-		display: flex;
-		flex-direction: column;
-		gap: 0.2rem;
-		padding: 0.75rem 1rem;
-		background: var(--card);
-		border: 1px solid var(--border);
-		border-radius: 0.5rem;
-		font-weight: 600;
-	}
-
-	.buckets .label {
-		font-size: 0.8rem;
-		font-weight: 400;
-		color: var(--ink-secondary);
-	}
-
-	.import-row {
-		display: flex;
-		align-items: end;
-		gap: 1rem;
-		margin-bottom: 1rem;
-		flex-wrap: wrap;
-	}
-
-	.file-label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		font-size: 0.9rem;
-	}
-
-	.banner {
-		max-width: 52rem;
-		box-sizing: border-box;
-		padding: 0.75rem 1rem;
-		background: var(--card);
-		border: 1px solid var(--border);
-		border-left: 3px solid var(--viz-1);
-		border-radius: 0.4rem;
-		margin-bottom: 1rem;
-		font-size: 0.9rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.3rem;
-	}
-
-	.banner .note {
-		color: var(--ink-secondary);
-	}
-
-	.banner .warning,
-	.import-actions .warning {
-		color: var(--error);
-	}
-
-	.table-wrap {
-		overflow-x: auto;
-		margin-bottom: 0.75rem;
-	}
-
-	.import-actions {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-		margin-bottom: 1.5rem;
-	}
-
-	tr.excluded {
-		opacity: 0.45;
-	}
-
-	.name-input {
-		width: 100%;
-		min-width: 14rem;
-		box-sizing: border-box;
-	}
-
-	.basis-input {
-		width: 7.5rem;
-		text-align: right;
-	}
-
-	.cell-input {
-		width: 8rem;
-		text-align: right;
-		padding: 0.25rem 0.45rem;
-		font-size: 0.95rem;
-	}
-
-	.row-actions {
-		display: flex;
-		gap: 0.75rem;
-		align-items: center;
-	}
-
-	.link.save {
-		color: var(--success);
-	}
-
-	table {
-		border-collapse: collapse;
-		width: 100%;
-		background: var(--card);
-		border: 1px solid var(--border);
-	}
-
-	th,
-	td {
-		text-align: left;
-		padding: 0.4rem 0.75rem;
-		border-bottom: 1px solid var(--border);
-	}
-
-	.num {
-		text-align: right;
-	}
-
-	.inline {
-		display: flex;
-		align-items: end;
-		gap: 1rem;
-		flex-wrap: wrap;
-	}
-
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		font-size: 0.9rem;
-	}
-
-	input,
-	select,
-	button {
-		padding: 0.4rem 0.6rem;
-		font-size: 1rem;
-	}
-
-	input[type='checkbox'] {
-		padding: 0;
-	}
-
-	.link {
-		background: none;
-		border: none;
-		color: var(--error);
-		cursor: pointer;
-		padding: 0;
-		font-size: 0.85rem;
-	}
-
-	.error {
-		color: var(--error);
-	}
-</style>

--- a/src/routes/retirement/accounts/+page.svelte
+++ b/src/routes/retirement/accounts/+page.svelte
@@ -5,6 +5,16 @@ import {
 	formatCents,
 	parseDollarsToCents,
 } from '$lib/argent/format';
+import {
+	banner,
+	bodyRow,
+	btn,
+	field,
+	input,
+	inputOnCard,
+	td,
+	th,
+} from '$lib/argent/styles';
 import type { PageProps } from './$types';
 
 let { data, form }: PageProps = $props();
@@ -67,19 +77,6 @@ const missingBasis = $derived(
 	),
 );
 
-// Shared Tailwind fragments (ghost design language — see DESIGN.md)
-const input =
-	'bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2.5 py-1.5 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
-const cellInput =
-	'bg-[var(--color-bg)] border border-[var(--color-border)] rounded px-2 py-1 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
-const btn =
-	'px-3 py-1.5 bg-[var(--color-accent)] text-white rounded text-sm font-medium hover:bg-[var(--color-accent-hover)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors';
-const label = 'flex flex-col gap-1 text-sm text-[var(--color-text-muted)]';
-const th = 'text-left py-2 px-3 text-[var(--color-text-muted)] font-medium';
-const td = 'py-2 px-3';
-const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
-const banner =
-	'py-3 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] border-l-2 border-l-[var(--color-accent)] rounded-lg mb-4 text-sm flex flex-col gap-1';
 </script>
 
 <h2 class="text-xl font-semibold mb-2">Accounts</h2>
@@ -114,7 +111,7 @@ const banner =
 	use:enhance
 	class="flex items-end gap-4 mb-4 flex-wrap"
 >
-	<label class={label}>
+	<label class={field}>
 		Import balances CSV (Date,Balance,Account)
 		<input class={input} name="balances" type="file" accept=".csv,text/csv" required />
 	</label>
@@ -167,10 +164,10 @@ const banner =
 					<tr class="{bodyRow} {row.include ? '' : 'opacity-45'}">
 						<td class={td}><input type="checkbox" class="accent-[var(--color-accent)]" bind:checked={row.include} /></td>
 						<td class={td}>
-							<input class="{cellInput} w-full min-w-56" bind:value={row.name} disabled={!row.include} />
+							<input class="{inputOnCard} w-full min-w-56" bind:value={row.name} disabled={!row.include} />
 						</td>
 						<td class={td}>
-							<select class={cellInput} bind:value={row.kind} disabled={!row.include}>
+							<select class={inputOnCard} bind:value={row.kind} disabled={!row.include}>
 								{#each data.accountKinds as k (k)}
 									<option value={k}>{KIND_LABELS[k]}</option>
 								{/each}
@@ -180,7 +177,7 @@ const banner =
 						<td class="{td} text-right">
 							{#if rowIsRoth(row)}
 								<input
-									class="{cellInput} w-30 text-right"
+									class="{inputOnCard} w-30 text-right"
 									bind:value={row.rothBasis}
 									placeholder="required"
 									disabled={!row.include}
@@ -228,7 +225,7 @@ const banner =
 						<td class={td}>{KIND_LABELS[account.kind] ?? account.kind}</td>
 						<td class="{td} text-right">
 							<input
-								class="{cellInput} w-32 text-right"
+								class="{inputOnCard} w-32 text-right"
 								name="balance"
 								form="acct-{account.id}"
 								value={dollars(account.balanceCents)}
@@ -238,7 +235,7 @@ const banner =
 						<td class="{td} text-right">
 							{#if account.kind === 'tsp-roth' || account.kind === 'ira-roth'}
 								<input
-									class="{cellInput} w-32 text-right"
+									class="{inputOnCard} w-32 text-right"
 									name="rothBasis"
 									form="acct-{account.id}"
 									value={dollars(account.rothBasisCents ?? 0)}
@@ -246,7 +243,7 @@ const banner =
 								/>
 							{:else if account.kind === 'taxable'}
 								<input
-									class="{cellInput} w-32 text-right"
+									class="{inputOnCard} w-32 text-right"
 									name="costBasis"
 									form="acct-{account.id}"
 									value={account.costBasisCents != null ? dollars(account.costBasisCents) : ''}
@@ -280,11 +277,11 @@ const banner =
 <h3 class="text-lg font-semibold mb-3">Add account</h3>
 
 <form method="POST" action="?/create" use:enhance class="flex items-end gap-4 flex-wrap">
-	<label class={label}>
+	<label class={field}>
 		Name
 		<input class={input} name="name" required />
 	</label>
-	<label class={label}>
+	<label class={field}>
 		Kind
 		<select class={input} name="kind" bind:value={kind}>
 			{#each data.accountKinds as k (k)}
@@ -292,12 +289,12 @@ const banner =
 			{/each}
 		</select>
 	</label>
-	<label class={label}>
+	<label class={field}>
 		Balance ($)
 		<input class={input} name="balance" required />
 	</label>
 	{#if isRoth}
-		<label class={label}>
+		<label class={field}>
 			Contribution basis ($)
 			<input class={input} name="rothBasis" required />
 		</label>

--- a/src/routes/retirement/expenses/+page.svelte
+++ b/src/routes/retirement/expenses/+page.svelte
@@ -15,198 +15,117 @@ const totalFor = (applies: string[]) =>
 	data.expenses
 		.filter((e) => applies.includes(e.applies))
 		.reduce((s, e) => s + e.annualCents, 0);
+
+// Shared Tailwind fragments (ghost design language — see DESIGN.md)
+const input =
+	'bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2.5 py-1.5 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
+const btn =
+	'px-3 py-1.5 bg-[var(--color-accent)] text-white rounded text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors';
+const label = 'flex flex-col gap-1 text-sm text-[var(--color-text-muted)]';
+const th = 'text-left py-2 px-3 text-[var(--color-text-muted)] font-medium';
+const td = 'py-2 px-3';
+const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 </script>
 
-<h1>Expenses</h1>
+<h2 class="text-xl font-semibold mb-2">Expenses</h2>
 
-<p class="hint">
+<p class="text-sm text-[var(--color-text-muted)] max-w-2xl mb-4">
 	Annual amounts in today's dollars, grown with inflation. "While working"
 	rows (commuting, work lunches…) stop at separation; "in retirement" rows
 	(travel…) start there. Don't add rows for payroll taxes, TSP, income
-	taxes, or <strong>health coverage</strong> — the engine computes those
+	taxes, or <strong class="text-[var(--color-text)]">health coverage</strong> — the engine computes those
 	(health premiums and Medicare from the Job screen and built-in constants,
 	switching automatically between FEHB, private-coverage gap, and Medicare
 	as retirement age changes).
 </p>
 
 {#if data.expenses.length > 0}
-	<section class="totals">
-		<div>
-			<span class="label">While working</span>
+	<section class="flex gap-4 mb-6 flex-wrap">
+		<div class="flex flex-col gap-0.5 py-3 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg font-semibold">
+			<span class="text-xs font-normal text-[var(--color-text-muted)]">While working</span>
 			<span>{formatCents(totalFor(['always', 'working']))}/yr</span>
 		</div>
-		<div>
-			<span class="label">In retirement</span>
+		<div class="flex flex-col gap-0.5 py-3 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg font-semibold">
+			<span class="text-xs font-normal text-[var(--color-text-muted)]">In retirement</span>
 			<span>{formatCents(totalFor(['always', 'retirement']))}/yr</span>
 		</div>
 	</section>
 
-	<table>
-		<thead>
-			<tr>
-				<th>Name</th>
-				<th class="num">Annual ($)</th>
-				<th>Applies</th>
-				<th></th>
-			</tr>
-		</thead>
-		<tbody>
-			{#each data.expenses as e (e.id)}
-				<tr>
-					<td>{e.name}</td>
-					<td class="num">
-						<input
-							class="cell-input"
-							name="annual"
-							form="exp-{e.id}"
-							value={dollars(e.annualCents)}
-							required
-						/>
-					</td>
-					<td>
-						<select name="applies" form="exp-{e.id}" value={e.applies}>
-							{#each Object.entries(APPLIES_LABELS) as [value, label] (value)}
-								<option {value}>{label}</option>
-							{/each}
-						</select>
-					</td>
-					<td class="row-actions">
-						<form id="exp-{e.id}" method="POST" action="?/update" use:enhance>
-							<input type="hidden" name="id" value={e.id} />
-							<button type="submit" class="link save">save</button>
-						</form>
-						<form method="POST" action="?/delete" use:enhance>
-							<input type="hidden" name="id" value={e.id} />
-							<button type="submit" class="link">delete</button>
-						</form>
-					</td>
+	<div class="overflow-x-auto bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg mb-6">
+		<table class="w-full border-collapse text-sm">
+			<thead>
+				<tr class="border-b border-[var(--color-border)]">
+					<th class={th}>Name</th>
+					<th class="{th} text-right">Annual ($)</th>
+					<th class={th}>Applies</th>
+					<th class={th}></th>
 				</tr>
-			{/each}
-		</tbody>
-	</table>
+			</thead>
+			<tbody>
+				{#each data.expenses as e (e.id)}
+					<tr class={bodyRow}>
+						<td class={td}>{e.name}</td>
+						<td class="{td} text-right">
+							<input
+								class="{input} w-32 text-right py-1 px-2 bg-[var(--color-bg)]"
+								name="annual"
+								form="exp-{e.id}"
+								value={dollars(e.annualCents)}
+								required
+							/>
+						</td>
+						<td class={td}>
+							<select
+								class="{input} py-1 px-2 bg-[var(--color-bg)]"
+								name="applies"
+								form="exp-{e.id}"
+								value={e.applies}
+							>
+								{#each Object.entries(APPLIES_LABELS) as [value, label] (value)}
+									<option {value}>{label}</option>
+								{/each}
+							</select>
+						</td>
+						<td class={td}>
+							<div class="flex gap-3 items-center">
+								<form id="exp-{e.id}" method="POST" action="?/update" use:enhance>
+									<input type="hidden" name="id" value={e.id} />
+									<button type="submit" class="text-xs text-[var(--color-success)] hover:underline">save</button>
+								</form>
+								<form method="POST" action="?/delete" use:enhance>
+									<input type="hidden" name="id" value={e.id} />
+									<button type="submit" class="text-xs text-[var(--color-error)] hover:underline">delete</button>
+								</form>
+							</div>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
 {:else}
-	<p>No expenses yet.</p>
+	<p class="text-[var(--color-text-muted)] mb-6">No expenses yet.</p>
 {/if}
 
-<h2>Add expense</h2>
+<h3 class="text-lg font-semibold mb-3">Add expense</h3>
 
-<form method="POST" action="?/create" use:enhance class="inline">
-	<label>
+<form method="POST" action="?/create" use:enhance class="flex items-end gap-4 flex-wrap">
+	<label class={label}>
 		Name
-		<input name="name" required />
+		<input class={input} name="name" required />
 	</label>
-	<label>
+	<label class={label}>
 		Annual ($)
-		<input name="annual" required />
+		<input class={input} name="annual" required />
 	</label>
-	<label>
+	<label class={label}>
 		Applies
-		<select name="applies">
+		<select class={input} name="applies">
 			{#each Object.entries(APPLIES_LABELS) as [value, label] (value)}
 				<option {value}>{label}</option>
 			{/each}
 		</select>
 	</label>
-	<button type="submit">Add</button>
-	{#if form?.error}<span class="error">{form.error}</span>{/if}
+	<button type="submit" class={btn}>Add</button>
+	{#if form?.error}<span class="text-sm text-[var(--color-error)]">{form.error}</span>{/if}
 </form>
-
-<style>
-	.hint {
-		color: var(--ink-secondary);
-		max-width: 42rem;
-	}
-
-	.totals {
-		display: flex;
-		gap: 1rem;
-		margin-bottom: 1.5rem;
-		flex-wrap: wrap;
-	}
-
-	.totals div {
-		display: flex;
-		flex-direction: column;
-		gap: 0.2rem;
-		padding: 0.75rem 1rem;
-		background: var(--card);
-		border: 1px solid var(--border);
-		border-radius: 0.5rem;
-		font-weight: 600;
-	}
-
-	.totals .label {
-		font-size: 0.8rem;
-		font-weight: 400;
-		color: var(--ink-secondary);
-	}
-
-	table {
-		border-collapse: collapse;
-		width: 100%;
-		background: var(--card);
-		border: 1px solid var(--border);
-	}
-
-	th,
-	td {
-		text-align: left;
-		padding: 0.4rem 0.75rem;
-		border-bottom: 1px solid var(--border);
-	}
-
-	.num {
-		text-align: right;
-	}
-
-	.cell-input {
-		width: 8rem;
-		text-align: right;
-		padding: 0.25rem 0.45rem;
-		font-size: 0.95rem;
-	}
-
-	.row-actions {
-		display: flex;
-		gap: 0.75rem;
-		align-items: center;
-	}
-
-	.link.save {
-		color: var(--success);
-	}
-
-	.inline {
-		display: flex;
-		align-items: end;
-		gap: 1rem;
-		flex-wrap: wrap;
-	}
-
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		font-size: 0.9rem;
-	}
-
-	input,
-	select,
-	button {
-		padding: 0.4rem 0.6rem;
-		font-size: 1rem;
-	}
-
-	.link {
-		background: none;
-		border: none;
-		color: var(--error);
-		cursor: pointer;
-		padding: 0;
-		font-size: 0.85rem;
-	}
-
-	.error {
-		color: var(--error);
-	}
-</style>

--- a/src/routes/retirement/expenses/+page.svelte
+++ b/src/routes/retirement/expenses/+page.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { centsToDollarsInput as dollars, formatCents } from '$lib/argent/format';
+import {
+	bodyRow,
+	btn,
+	field,
+	input,
+	inputOnCard,
+	td,
+	th,
+} from '$lib/argent/styles';
 import type { PageProps } from './$types';
 
 let { data, form }: PageProps = $props();
@@ -16,15 +25,6 @@ const totalFor = (applies: string[]) =>
 		.filter((e) => applies.includes(e.applies))
 		.reduce((s, e) => s + e.annualCents, 0);
 
-// Shared Tailwind fragments (ghost design language — see DESIGN.md)
-const input =
-	'bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2.5 py-1.5 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
-const btn =
-	'px-3 py-1.5 bg-[var(--color-accent)] text-white rounded text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors';
-const label = 'flex flex-col gap-1 text-sm text-[var(--color-text-muted)]';
-const th = 'text-left py-2 px-3 text-[var(--color-text-muted)] font-medium';
-const td = 'py-2 px-3';
-const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 </script>
 
 <h2 class="text-xl font-semibold mb-2">Expenses</h2>
@@ -67,7 +67,7 @@ const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 						<td class={td}>{e.name}</td>
 						<td class="{td} text-right">
 							<input
-								class="{input} w-32 text-right py-1 px-2 bg-[var(--color-bg)]"
+								class="{inputOnCard} w-32 text-right"
 								name="annual"
 								form="exp-{e.id}"
 								value={dollars(e.annualCents)}
@@ -76,7 +76,7 @@ const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 						</td>
 						<td class={td}>
 							<select
-								class="{input} py-1 px-2 bg-[var(--color-bg)]"
+								class={inputOnCard}
 								name="applies"
 								form="exp-{e.id}"
 								value={e.applies}
@@ -110,15 +110,15 @@ const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 <h3 class="text-lg font-semibold mb-3">Add expense</h3>
 
 <form method="POST" action="?/create" use:enhance class="flex items-end gap-4 flex-wrap">
-	<label class={label}>
+	<label class={field}>
 		Name
 		<input class={input} name="name" required />
 	</label>
-	<label class={label}>
+	<label class={field}>
 		Annual ($)
 		<input class={input} name="annual" required />
 	</label>
-	<label class={label}>
+	<label class={field}>
 		Applies
 		<select class={input} name="applies">
 			{#each Object.entries(APPLIES_LABELS) as [value, label] (value)}

--- a/src/routes/retirement/job/+page.svelte
+++ b/src/routes/retirement/job/+page.svelte
@@ -24,11 +24,21 @@ const initial = $derived({
 		parsed?.employeeHealthCents ?? data.job.employeeHealthCents,
 	),
 });
+
+// Shared Tailwind fragments (ghost design language — see DESIGN.md)
+const input =
+	'bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2.5 py-1.5 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
+const btn =
+	'px-3 py-1.5 bg-[var(--color-accent)] text-white rounded text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors';
+const label = 'flex flex-col gap-1 text-sm text-[var(--color-text-muted)]';
+const th = 'text-left py-2 px-3 text-[var(--color-text-muted)] font-medium';
+const td = 'py-2 px-3';
+const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 </script>
 
-<h1>Job</h1>
+<h2 class="text-xl font-semibold mb-2">Job</h2>
 
-<p class="hint">
+<p class="text-sm text-[var(--color-text-muted)] max-w-2xl mb-4">
 	Federal job details. Total compensation = salary + employer health
 	contribution + employer TSP (1% automatic + match on your contribution).
 </p>
@@ -38,213 +48,115 @@ const initial = $derived({
 	action="?/importLes"
 	enctype="multipart/form-data"
 	use:enhance
-	class="import-row"
+	class="flex items-end gap-4 mb-4 flex-wrap"
 >
-	<label class="file-label">
+	<label class={label}>
 		Import from LES (DFAS PDF)
-		<input name="les" type="file" accept="application/pdf" required />
+		<input class={input} name="les" type="file" accept="application/pdf" required />
 	</label>
-	<button type="submit">Parse LES</button>
+	<button type="submit" class={btn}>Parse LES</button>
 </form>
 
 {#if parsed}
-	<div class="banner">
+	<div class="max-w-2xl py-3 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] border-l-2 border-l-[var(--color-accent)] rounded-lg mb-4 text-sm flex flex-col gap-1">
 		<strong>Imported{parsed.gradeStep ? ` — ${parsed.gradeStep}` : ''}</strong>
 		{#if parsed.payPeriodEnd}(pay period ending {parsed.payPeriodEnd}){/if}
 		— review the prefilled fields below, then Save.
 		{#each parsed.warnings as w (w)}
-			<span class="warning">⚠ {w}</span>
+			<span class="text-[var(--color-error)]">⚠ {w}</span>
 		{/each}
 	</div>
 {/if}
 
 {#key parsed}
-	<form method="POST" action="?/save" use:enhance class="grid">
-		<label>
+	<form method="POST" action="?/save" use:enhance class="grid grid-cols-[repeat(2,minmax(0,20rem))] gap-4">
+		<label class={label}>
 			Base salary (annual $)
-			<input name="salary" value={initial.salary} required />
+			<input class={input} name="salary" value={initial.salary} required />
 		</label>
-		<label>
+		<label class={label}>
 			Service start date
-			<input name="serviceStartDate" type="date" value={initial.serviceStartDate} required />
+			<input class={input} name="serviceStartDate" type="date" value={initial.serviceStartDate} required />
 		</label>
-		<label>
+		<label class={label}>
 			TSP — traditional (% of salary)
-			<input name="tspTraditional" value={initial.tspTraditional} required />
+			<input class={input} name="tspTraditional" value={initial.tspTraditional} required />
 		</label>
-		<label>
+		<label class={label}>
 			TSP — Roth (% of salary)
-			<input name="tspRoth" value={initial.tspRoth} required />
+			<input class={input} name="tspRoth" value={initial.tspRoth} required />
 		</label>
-		<label>
+		<label class={label}>
 			FERS contribution (% of salary)
-			<input name="fersContribution" value={initial.fersContribution} required />
+			<input class={input} name="fersContribution" value={initial.fersContribution} required />
 		</label>
-		<label>
+		<label class={label}>
 			Employer health contribution (annual $)
-			<input name="employerHealth" value={initial.employerHealth} required />
+			<input class={input} name="employerHealth" value={initial.employerHealth} required />
 		</label>
-		<label>
+		<label class={label}>
 			Your health premium (annual $, pre-tax)
-			<input name="employeeHealth" value={initial.employeeHealth} required />
+			<input class={input} name="employeeHealth" value={initial.employeeHealth} required />
 		</label>
-		<div class="actions">
-			<button type="submit">Save</button>
-			{#if form?.error}<span class="error">{form.error}</span>{/if}
+		<div class="col-span-full flex items-center gap-4">
+			<button type="submit" class={btn}>Save</button>
+			{#if form?.error}<span class="text-sm text-[var(--color-error)]">{form.error}</span>{/if}
 		</div>
 	</form>
 {/key}
 
-<h2>Social Security earnings record</h2>
+<h3 class="text-lg font-semibold mt-8 mb-2">Social Security earnings record</h3>
 
-<p class="hint">
+<p class="text-sm text-[var(--color-text-muted)] max-w-2xl mb-4">
 	From your SSA statement's earnings table — used to compute your actual
 	benefit (the statement's own estimate assumes you never stop working).
 	Re-adding a year overwrites it.
 </p>
 
 {#if data.earnings.length > 0}
-	<table>
-		<thead>
-			<tr><th>Year</th><th class="num">Covered earnings</th><th></th></tr>
-		</thead>
-		<tbody>
-			{#each data.earnings as row (row.year)}
-				<tr>
-					<td>{row.year}</td>
-					<td class="num">
-						{(row.earningsCents / 100).toLocaleString('en-US', {
-							style: 'currency',
-							currency: 'USD',
-							maximumFractionDigits: 0,
-						})}
-					</td>
-					<td>
-						<form method="POST" action="?/deleteEarnings" use:enhance>
-							<input type="hidden" name="year" value={row.year} />
-							<button type="submit" class="link">delete</button>
-						</form>
-					</td>
+	<div class="inline-block overflow-x-auto bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg mb-4">
+		<table class="border-collapse text-sm">
+			<thead>
+				<tr class="border-b border-[var(--color-border)]">
+					<th class={th}>Year</th>
+					<th class="{th} text-right">Covered earnings</th>
+					<th class={th}></th>
 				</tr>
-			{/each}
-		</tbody>
-	</table>
+			</thead>
+			<tbody>
+				{#each data.earnings as row (row.year)}
+					<tr class={bodyRow}>
+						<td class={td}>{row.year}</td>
+						<td class="{td} text-right tabular-nums">
+							{(row.earningsCents / 100).toLocaleString('en-US', {
+								style: 'currency',
+								currency: 'USD',
+								maximumFractionDigits: 0,
+							})}
+						</td>
+						<td class={td}>
+							<form method="POST" action="?/deleteEarnings" use:enhance>
+								<input type="hidden" name="year" value={row.year} />
+								<button type="submit" class="text-xs text-[var(--color-error)] hover:underline">delete</button>
+							</form>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
 {:else}
-	<p>No earnings history entered yet.</p>
+	<p class="text-[var(--color-text-muted)] mb-4">No earnings history entered yet.</p>
 {/if}
 
-<form method="POST" action="?/addEarnings" use:enhance class="inline">
-	<label>
+<form method="POST" action="?/addEarnings" use:enhance class="flex items-end gap-4 mt-2 flex-wrap">
+	<label class={label}>
 		Year
-		<input name="year" type="number" min="1950" max="2100" required />
+		<input class="{input} w-24" name="year" type="number" min="1950" max="2100" required />
 	</label>
-	<label>
+	<label class={label}>
 		Earnings ($)
-		<input name="earnings" required />
+		<input class={input} name="earnings" required />
 	</label>
-	<button type="submit">Add / update year</button>
+	<button type="submit" class={btn}>Add / update year</button>
 </form>
-
-<style>
-	.hint {
-		color: var(--ink-secondary);
-		max-width: 40rem;
-	}
-
-	.import-row {
-		display: flex;
-		align-items: end;
-		gap: 1rem;
-		margin-bottom: 1rem;
-		flex-wrap: wrap;
-	}
-
-	.file-label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		font-size: 0.9rem;
-	}
-
-	.banner {
-		max-width: 41rem;
-		box-sizing: border-box;
-		padding: 0.75rem 1rem;
-		background: var(--card);
-		border: 1px solid var(--border);
-		border-left: 3px solid var(--viz-1);
-		border-radius: 0.4rem;
-		margin-bottom: 1rem;
-		font-size: 0.9rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.3rem;
-	}
-
-	.banner .warning {
-		color: var(--error);
-	}
-
-	.grid {
-		display: grid;
-		grid-template-columns: repeat(2, minmax(0, 20rem));
-		gap: 1rem;
-	}
-
-	label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		font-size: 0.9rem;
-	}
-
-	input,
-	button {
-		padding: 0.4rem 0.6rem;
-		font-size: 1rem;
-	}
-
-	.actions {
-		grid-column: 1 / -1;
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-	}
-
-	.inline {
-		display: flex;
-		align-items: end;
-		gap: 1rem;
-		margin-top: 1rem;
-	}
-
-	table {
-		border-collapse: collapse;
-		background: var(--card);
-		border: 1px solid var(--border);
-	}
-
-	th,
-	td {
-		text-align: left;
-		padding: 0.35rem 0.75rem;
-		border-bottom: 1px solid var(--border);
-	}
-
-	.num {
-		text-align: right;
-	}
-
-	.link {
-		background: none;
-		border: none;
-		color: var(--error);
-		cursor: pointer;
-		padding: 0;
-		font-size: 0.85rem;
-	}
-
-	.error {
-		color: var(--error);
-	}
-</style>

--- a/src/routes/retirement/job/+page.svelte
+++ b/src/routes/retirement/job/+page.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { centsToDollarsInput as dollars } from '$lib/argent/format';
+import {
+	banner,
+	bodyRow,
+	btn,
+	field,
+	input,
+	td,
+	th,
+} from '$lib/argent/styles';
 import type { PageProps } from './$types';
 
 let { data, form }: PageProps = $props();
@@ -24,16 +33,6 @@ const initial = $derived({
 		parsed?.employeeHealthCents ?? data.job.employeeHealthCents,
 	),
 });
-
-// Shared Tailwind fragments (ghost design language — see DESIGN.md)
-const input =
-	'bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2.5 py-1.5 text-[var(--color-text)] outline-none focus:border-[var(--color-accent)] transition-colors';
-const btn =
-	'px-3 py-1.5 bg-[var(--color-accent)] text-white rounded text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors';
-const label = 'flex flex-col gap-1 text-sm text-[var(--color-text-muted)]';
-const th = 'text-left py-2 px-3 text-[var(--color-text-muted)] font-medium';
-const td = 'py-2 px-3';
-const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 </script>
 
 <h2 class="text-xl font-semibold mb-2">Job</h2>
@@ -50,7 +49,7 @@ const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 	use:enhance
 	class="flex items-end gap-4 mb-4 flex-wrap"
 >
-	<label class={label}>
+	<label class={field}>
 		Import from LES (DFAS PDF)
 		<input class={input} name="les" type="file" accept="application/pdf" required />
 	</label>
@@ -58,7 +57,7 @@ const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 </form>
 
 {#if parsed}
-	<div class="max-w-2xl py-3 px-4 bg-[var(--color-surface)] border border-[var(--color-border)] border-l-2 border-l-[var(--color-accent)] rounded-lg mb-4 text-sm flex flex-col gap-1">
+	<div class="{banner} max-w-2xl">
 		<strong>Imported{parsed.gradeStep ? ` — ${parsed.gradeStep}` : ''}</strong>
 		{#if parsed.payPeriodEnd}(pay period ending {parsed.payPeriodEnd}){/if}
 		— review the prefilled fields below, then Save.
@@ -70,31 +69,31 @@ const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 
 {#key parsed}
 	<form method="POST" action="?/save" use:enhance class="grid grid-cols-[repeat(2,minmax(0,20rem))] gap-4">
-		<label class={label}>
+		<label class={field}>
 			Base salary (annual $)
 			<input class={input} name="salary" value={initial.salary} required />
 		</label>
-		<label class={label}>
+		<label class={field}>
 			Service start date
 			<input class={input} name="serviceStartDate" type="date" value={initial.serviceStartDate} required />
 		</label>
-		<label class={label}>
+		<label class={field}>
 			TSP — traditional (% of salary)
 			<input class={input} name="tspTraditional" value={initial.tspTraditional} required />
 		</label>
-		<label class={label}>
+		<label class={field}>
 			TSP — Roth (% of salary)
 			<input class={input} name="tspRoth" value={initial.tspRoth} required />
 		</label>
-		<label class={label}>
+		<label class={field}>
 			FERS contribution (% of salary)
 			<input class={input} name="fersContribution" value={initial.fersContribution} required />
 		</label>
-		<label class={label}>
+		<label class={field}>
 			Employer health contribution (annual $)
 			<input class={input} name="employerHealth" value={initial.employerHealth} required />
 		</label>
-		<label class={label}>
+		<label class={field}>
 			Your health premium (annual $, pre-tax)
 			<input class={input} name="employeeHealth" value={initial.employeeHealth} required />
 		</label>
@@ -150,11 +149,11 @@ const bodyRow = 'border-b border-[var(--color-border)] last:border-b-0';
 {/if}
 
 <form method="POST" action="?/addEarnings" use:enhance class="flex items-end gap-4 mt-2 flex-wrap">
-	<label class={label}>
+	<label class={field}>
 		Year
 		<input class="{input} w-24" name="year" type="number" min="1950" max="2100" required />
 	</label>
-	<label class={label}>
+	<label class={field}>
 		Earnings ($)
 		<input class={input} name="earnings" required />
 	</label>

--- a/static/icon-retirement.svg
+++ b/static/icon-retirement.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="retireGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#67e8f9"/>
+      <stop offset="50%" style="stop-color:#06b6d4"/>
+      <stop offset="100%" style="stop-color:#0e7490"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Outer glow -->
+  <rect x="1" y="2" width="30" height="28" rx="3" fill="#06b6d4" opacity="0.1"/>
+
+  <!-- Chart frame -->
+  <rect x="2" y="3" width="28" height="26" rx="2" fill="#06b6d4" opacity="0.15"/>
+  <rect x="2" y="3" width="28" height="26" rx="2" fill="none" stroke="url(#retireGrad)" stroke-width="1.5"/>
+
+  <!-- Axes -->
+  <path d="M6 7 L6 25 L27 25" fill="none" stroke="#0e7490" stroke-width="1"/>
+
+  <!-- Wealth area (growth curve filled to baseline) -->
+  <path d="M6 23 L11 21 L16 17 L21 12 L26 9 L26 25 L6 25 Z" fill="url(#retireGrad)" opacity="0.35"/>
+  <path d="M6 23 L11 21 L16 17 L21 12 L26 9" fill="none" stroke="#67e8f9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Milestone dots along the curve -->
+  <circle cx="11" cy="21" r="1.2" fill="#67e8f9"/>
+  <circle cx="16" cy="17" r="1.2" fill="#67e8f9"/>
+  <circle cx="21" cy="12" r="1.2" fill="#67e8f9"/>
+
+  <!-- Nest-egg coin at the summit -->
+  <circle cx="26" cy="9" r="3.5" fill="#0e7490"/>
+  <circle cx="26" cy="9" r="3.5" fill="none" stroke="#67e8f9" stroke-width="1"/>
+  <path d="M26 7.2 L26 10.8 M24.9 8 Q26 7 27.1 8 Q26 9 24.9 10 Q26 11 27.1 10" fill="none" stroke="#67e8f9" stroke-width="0.8" stroke-linecap="round"/>
+
+  <!-- Scan lines -->
+  <g opacity="0.2">
+    <line x1="2" y1="11" x2="30" y2="11" stroke="#67e8f9" stroke-width="0.5"/>
+    <line x1="2" y1="17" x2="30" y2="17" stroke="#67e8f9" stroke-width="0.5"/>
+    <line x1="2" y1="23" x2="30" y2="23" stroke="#67e8f9" stroke-width="0.5"/>
+  </g>
+</svg>


### PR DESCRIPTION
Closes #11.

Converts the ported argent retirement micro-app from its scoped-CSS styling to ghost's Tailwind 4 dark "ghost in the machine" design language, and removes the variable-bridge that was holding the two systems together.

## What changed

- **Design tokens** (`src/app.css`, `DESIGN.md`): new status tokens (`--color-success`, `--color-error`) and a five-slot categorical data-viz palette (`--color-viz-1..5`), cyan-led to match the brand accent. The palette was validated colorblind-safe as a set against `--color-surface` with the dataviz six-checks validator (worst adjacent CVD ΔE 13.2, normal-vision 19.3, all slots ≥3:1 contrast) — if a hue ever changes, re-validate the set rather than eyeballing.
- **Pages** (`projection`, `job`, `accounts`, `expenses`): scoped CSS replaced with Tailwind utilities on ghost tokens, matching the card/form/table patterns of the other micro-apps. Repeated class strings are hoisted to script-level constants. The section layout gains an icon + "Retirement" header (new `static/icon-retirement.svg`); page titles demote to `h2`.
- **Chart** (`TimeSeriesChart.svelte`): rethemed in place to read ghost tokens directly — kept the custom SVG implementation rather than porting to Chart.js, preserving the crosshair/tooltip/keyboard interactions and stacked-area gap rendering.
- **Bridge dropped**: `retirement/+layout.svelte` no longer defines argent tokens; zero argent token references remain under `src/routes/retirement` or `src/lib/argent`.

## Verification

- `bun run check` clean (0 errors; 15 pre-existing warnings).
- `bun test`: 144/145 pass — the one failure is pre-existing (`tests/tasks.spec.ts` is a Playwright e2e spec that Bun's unit runner sweeps up).
- All four pages SSR cleanly with the new tokens; icon serves.
- Not screenshot-verified: no browser in the container and the Playwright browser download is firewalled (`storage.googleapis.com`) — please eyeball the four pages before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeEhetRECDEDxZFFFV4U34